### PR TITLE
Fix loading

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -19,11 +19,21 @@ function App() {
 
   useEffect(() => {
     const combatIdMatch = route.match(/^#play\/([a-zA-Z0-9]+)$/);
-    if (combatIdMatch && !combatStateManager.state.combatId) {
-      setIsLoading(true);
-      combatStateManager.loadCombat(combatIdMatch[1]).finally(() => {
-        setIsLoading(false);
-      });
+    if (combatIdMatch) {
+      const newCombatId = combatIdMatch[1];
+      
+      // Only load if it's a different combat or no combat is loaded
+      if (newCombatId !== combatStateManager.state.combatId) {
+        setIsLoading(true);
+        combatStateManager.loadCombat(newCombatId).finally(() => {
+          setIsLoading(false);
+        });
+      }
+    } else {
+      // Reset state when navigating back to combat list
+      if (combatStateManager.state.combatId) {
+        combatStateManager.resetState();
+      }
     }
   }, [combatStateManager, route]);
 


### PR DESCRIPTION
This pull request improves the handling of combat state when navigating between combats and the combat list in the `App` component. The main change ensures that combat data is only loaded if the combat ID has changed, and resets the state when navigating away from a combat.

Combat state management improvements:

* Updated the `useEffect` in `src/App.tsx` to only load combat data if the combat ID from the route is different from the currently loaded combat, preventing unnecessary reloads.
* Added logic to reset the combat state when navigating back to the combat list, ensuring stale combat data is cleared.