### PR TITLE
Reload monster and player after a sync

### DIFF
--- a/src/state.ts
+++ b/src/state.ts
@@ -131,18 +131,23 @@ export function useCombatState(): CombatStateManager {
   };
 
   const hasNewRemoteData = async () => {
-    return await dataStore.hasNewRemoteData()
-  }
+    return await dataStore.hasNewRemoteData();
+  };
 
   const synchronise = async () => {
     try {
       await dataStore.syncToCloud();
+
+      // Reload data after sync to reflect any downloaded changes
+      await loadPlayers();
+      await loadMonsters();
+
       toastApi.success(`Sync successful`);
       return true;
     } catch (error) {
       toastApi.error(`Error while syncing data ${error}`);
     }
-    return false
+    return false;
   };
 
   const logout = async () => {
@@ -157,11 +162,11 @@ export function useCombatState(): CombatStateManager {
   };
 
   const getLastSyncTime = () => {
-    return dataStore.getLastSyncTime()
+    return dataStore.getLastSyncTime();
   };
 
   const isSyncAuthorized = () => {
-    return dataStore.isSyncAuthorized()
+    return dataStore.isSyncAuthorized();
   };
 
   const loadPlayers = useCallback(async () => {


### PR DESCRIPTION
This pull request improves the reliability of data synchronization in the combat state manager by ensuring that local player and monster data is refreshed after syncing with the cloud. It also makes minor style updates for code consistency.

Data synchronization improvements:

* Updated the `synchronise` function in `src/state.ts` to reload player and monster data after syncing to the cloud, ensuring the UI reflects any changes downloaded during the sync.

Code style and consistency:

* Added missing semicolons to several return statements in `src/state.ts` for consistency and readability.