### PR TITLE
Move combatant form in modal

### DIFF
--- a/src/components/CombatForm/AddCombatantForm.tsx
+++ b/src/components/CombatForm/AddCombatantForm.tsx
@@ -1,25 +1,34 @@
-import { type RefObject } from "react";
 import { useTranslation } from "react-i18next";
 import type { InitiativeGroup, NewCombatant, SearchResult } from "../../types";
 import LabeledTextInput from "../common/LabeledTextInput";
 import LabeledNumberInput from "../common/LabeledNumberInput";
 import ColorPicker from "../common/ColorPicker";
 import InitiativeGroupInput from "./InitiativeGroupInput";
-import { ChevronDown, Save, Sword, CircleParking, Dice3, BookOpen } from "lucide-react";
+import {
+  Save,
+  Sword,
+  CircleParking,
+  Dice3,
+} from "lucide-react";
 import CombatantNameWithSearch from "./CombatantNameWithSearch";
 import { isNewCombatantInvalid, safeParseInt } from "../../utils";
 
-type ButtonType = "fight" | "park" | "savePlayer" | "addToLibrary" | "addInitGroup";
+type ButtonType =
+  | "fight"
+  | "park"
+  | "savePlayer"
+  | "addToLibrary"
+  | "addInitGroup";
 
 type Props = {
-  formRef?: RefObject<HTMLDivElement | null>;
-  value: NewCombatant;
+  newCombatant: NewCombatant;
   stagedFrom?: string;
   totalCount: number;
-  isCollapsed?: boolean;
-  inModal?: boolean;
   visibleButtons?: ButtonType[];
-  onToggleCollapse?: (collapsed: boolean) => void;
+  addToFightChecked: boolean;
+  onAddToFightChange: (checked: boolean) => void;
+  addAnotherChecked: boolean;
+  onAddAnotherChange: (checked: boolean) => void;
   onChange: (patch: Partial<NewCombatant>) => void;
   onSubmit: () => void;
   onAddGroup: () => void;
@@ -32,18 +41,18 @@ type Props = {
   ) => void;
   onSearchMonsters: (searchName: string) => Promise<SearchResult[]>;
   onSelectSearchResult: (searchResult: SearchResult) => void;
-  onAddToLibrary: () => void
+  onAddToLibrary: () => void;
 };
 
 export default function AddCombatantForm({
-  formRef,
-  value,
+  newCombatant,
   stagedFrom,
   totalCount,
-  isCollapsed = false,
-  inModal = false,
   visibleButtons,
-  onToggleCollapse,
+  addToFightChecked,
+  onAddToFightChange,
+  addAnotherChecked,
+  onAddAnotherChange,
   onChange,
   onSubmit,
   onAddGroup,
@@ -53,7 +62,7 @@ export default function AddCombatantForm({
   onUpdateInitiativeGroup,
   onSearchMonsters,
   onSelectSearchResult,
-  onAddToLibrary
+  onAddToLibrary,
 }: Props) {
   const { t } = useTranslation("forms");
 
@@ -69,215 +78,206 @@ export default function AddCombatantForm({
   };
 
   const content = (
-    <div className={inModal ? "" : "px-6 pb-6"}>
-          {stagedFrom && (
-            <div className="mb-3 text-sm text-slate-300">
-              {t("forms:combatant.stagedFrom")}{" "}
-              <span className="font-semibold">{stagedFrom}</span>.
-            </div>
-          )}
-
-          <div className="grid grid-cols-1 md:grid-cols-2 gap-4 mb-4">
-            <CombatantNameWithSearch
-              id="combatantName"
-              label={t("forms:combatant.name")}
-              value={value.name}
-              placeholder={t("forms:combatant.groupNamePlaceholder")}
-              onChange={(v) => onChange({ name: v })}
-              onSearch={onSearchMonsters}
-              onSelectResult={onSelectSearchResult}
-            />
-            <ColorPicker
-              value={value.color}
-              onChange={(v) => onChange({ color: v })}
-            />
-          </div>
-
-          <div className="grid grid-cols-1 md:grid-cols-2 gap-4 mb-4">
-            <LabeledTextInput
-              id="combatImageUrl"
-              label={t("forms:combatant.imageUrl")}
-              value={value.imageUrl || ""}
-              placeholder={t("forms:combatant.imageUrlPlaceholder")}
-              onChange={(v) => onChange({ imageUrl: v })}
-            />
-            <LabeledTextInput
-              id="externalResourceUrl"
-              label={t("forms:combatant.externalResourceUrl")}
-              value={value.externalResourceUrl || ""}
-              placeholder={t("forms:combatant.externalResourceUrlPlacehoder")}
-              onChange={(v) => onChange({ externalResourceUrl: v })}
-            />
-            <LabeledNumberInput
-              id="combatHp"
-              label={t("forms:combatant.currentHp")}
-              value={value.hp ?? ""}
-              placeholder={t("forms:combatant.currentHpPlaceholder")}
-              onChange={(v) => onChange({ hp: safeParseInt(v) })}
-            />
-            <LabeledNumberInput
-              id="combatMaxHp"
-              label={t("forms:combatant.maxHp")}
-              value={value.maxHp ?? ""}
-              placeholder={t("forms:combatant.maxHpPlaceholder")}
-              onChange={(v) => onChange({ maxHp: safeParseInt(v) })}
-            />
-            <LabeledNumberInput
-              id="combatAc"
-              label={t("forms:combatant.ac")}
-              value={value.ac ?? ""}
-              placeholder={t("forms:combatant.acPlaceholder")}
-              onChange={(v) => onChange({ ac: safeParseInt(v) })}
-            />
-
-            <LabeledNumberInput
-              id="initBonus"
-              label={t("forms:combatant.initBonus")}
-              value={value.initBonus ?? ""}
-              placeholder={t("forms:combatant.initBonusPlaceholder")}
-              onChange={(v) => onChange({ initBonus: safeParseInt(v, true) })}
-            />
-          </div>
-
-          <div className="mb-4">
-            <div className="flex items-center justify-between mb-2">
-              <label className="text-sm font-medium text-slate-300">
-                {t("forms:combatant.initiative")}
-                {totalCount > 0 && (
-                  <span className="ml-2 text-blue-400 text-xs">
-                    {t("forms:combatant.initiativeHint", {
-                      count: totalCount,
-                      range: getLetterRange(),
-                    })}
-                  </span>
-                )}
-              </label>
-            </div>
-
-            <div className="grid grid-cols-2 md:grid-cols-4 gap-2">
-              {value.initiativeGroups.map((group, index) => (
-                <InitiativeGroupInput
-                  key={group.id}
-                  group={group}
-                  index={index}
-                  initBonus={value.initBonus}
-                  canRemove={value.initiativeGroups.length > 1}
-                  onChange={onUpdateInitiativeGroup}
-                  onRemove={onRemoveInitiativeGroup}
-                />
-              ))}
-            </div>
-          </div>
-
-          {/* Add to Fight Checkbox - Only show in player/group modes */}
-          {(isButtonVisible("savePlayer") || isButtonVisible("park")) && (
-            <div className="mb-4">
-              <label className="flex items-center gap-2 text-slate-300 cursor-pointer">
-                <input
-                  type="checkbox"
-                  checked={value.addToFight ?? false}
-                  onChange={(e) => onChange({ addToFight: e.target.checked })}
-                  className="w-4 h-4 rounded border-slate-600 bg-slate-700 text-lime-600 focus:ring-lime-600 focus:ring-offset-slate-800"
-                />
-                <span className="text-sm font-medium">{t("forms:combatant.addToFight")}</span>
-              </label>
-            </div>
-          )}
-
-          <div className="grid grid-cols-2 md:flex gap-2 md:gap-3 mt-4">
-            {isButtonVisible("fight") && (
-              <button
-                onClick={onSubmit}
-                className="disabled:pointer-events-none disabled:opacity-50 bg-lime-600 hover:bg-lime-700 text-white px-4 py-3 rounded flex items-center justify-center gap-2 transition"
-                title={t("forms:combatant.actions.fight")}
-                disabled={isNewCombatantInvalid(value)}
-              >
-                <Sword className="w-5 h-5" />
-                <span className="hidden md:inline">
-                  {t("forms:combatant.actions.fight")}
-                </span>
-              </button>
-            )}
-            {isButtonVisible("park") && (
-              <button
-                onClick={onAddGroup}
-                className="disabled:pointer-events-none disabled:opacity-50 bg-sky-600 hover:bg-sky-500 text-white px-4 py-3 rounded flex items-center justify-center gap-2 transition"
-                title={t("forms:combatant.actions.park")}
-                disabled={isNewCombatantInvalid(value)}
-              >
-                <CircleParking className="w-5 h-5" />
-                <span className="hidden md:inline">{t("forms:combatant.actions.park")}</span>
-              </button>
-            )}
-            {isButtonVisible("savePlayer") && (
-              <button
-                onClick={onSaveAsPlayer}
-                className="disabled:pointer-events-none disabled:opacity-50 bg-purple-600 hover:bg-purple-700 text-white px-4 py-3 rounded flex items-center justify-center gap-2 transition"
-                title={t("forms:combatant.actions.savePlayer")}
-                disabled={isNewCombatantInvalid(value)}
-              >
-                <Save className="w-5 h-5" />
-                <span className="hidden md:inline">{t("forms:combatant.actions.savePlayer")}</span>
-              </button>
-            )}
-            {isButtonVisible("addToLibrary") && (
-              <button
-                onClick={onAddToLibrary}
-                className="disabled:pointer-events-none disabled:opacity-50 bg-amber-600 hover:bg-amber-700 text-white px-4 py-3 rounded flex items-center justify-center gap-2 transition"
-                title={t("forms:combatant.actions.addToLibrary")}
-                disabled={isNewCombatantInvalid(value)}
-              >
-                <BookOpen className="w-5 h-5" />
-                <span className="hidden md:inline">{t("forms:combatant.actions.addToLibrary")}</span>
-              </button>
-            )}
-            {isButtonVisible("addInitGroup") && (
-              <button
-                onClick={onAddInitiativeGroup}
-                className="bg-slate-600 hover:bg-slate-700 text-white px-4 py-3 rounded flex items-center justify-center gap-2 transition"
-                title={t("forms:combatant.actions.addInitGroup")}
-              >
-                <Dice3 className="w-5 h-5" />
-                <span className="hidden md:inline">
-                  {t("forms:combatant.actions.addInitGroup")}
-                </span>
-              </button>
-            )}
-          </div>
+    <div>
+      {stagedFrom && (
+        <div className="mb-3 text-sm text-slate-300">
+          {t("forms:combatant.stagedFrom")}{" "}
+          <span className="font-semibold">{stagedFrom}</span>.
         </div>
-  );
+      )}
 
-  if (inModal) {
-    return content;
-  }
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-4 mb-4">
+        <CombatantNameWithSearch
+          id="combatantName"
+          label={t("forms:combatant.name")}
+          value={newCombatant.name}
+          placeholder={t("forms:combatant.groupNamePlaceholder")}
+          onChange={(v) => onChange({ name: v })}
+          onSearch={onSearchMonsters}
+          onSelectResult={onSelectSearchResult}
+        />
+        <ColorPicker
+          value={newCombatant.color}
+          onChange={(v) => onChange({ color: v })}
+        />
+      </div>
 
-  return (
-    <div
-      ref={formRef}
-      className="bg-slate-800 rounded-lg border border-slate-700 mb-6 overflow-hidden"
-    >
-      <button
-        onClick={() => onToggleCollapse?.(! isCollapsed)}
-        className="w-full flex items-center justify-between p-6 hover:bg-slate-700 transition-colors"
-      >
-        <h2 className="text-xl font-semibold">{t("forms:combatant.title")}</h2>
-        <div
-          className="transition-transform duration-300"
-          style={{ transform: isCollapsed ? "rotate(0deg)" : "rotate(180deg)" }}
-        >
-          <ChevronDown className="w-5 h-5 text-slate-400" />
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-4 mb-4">
+        <LabeledTextInput
+          id="combatImageUrl"
+          label={t("forms:combatant.imageUrl")}
+          value={newCombatant.imageUrl || ""}
+          placeholder={t("forms:combatant.imageUrlPlaceholder")}
+          onChange={(v) => onChange({ imageUrl: v })}
+        />
+        <LabeledTextInput
+          id="externalResourceUrl"
+          label={t("forms:combatant.externalResourceUrl")}
+          value={newCombatant.externalResourceUrl || ""}
+          placeholder={t("forms:combatant.externalResourceUrlPlacehoder")}
+          onChange={(v) => onChange({ externalResourceUrl: v })}
+        />
+        <LabeledNumberInput
+          id="combatHp"
+          label={t("forms:combatant.currentHp")}
+          value={newCombatant.hp ?? ""}
+          placeholder={t("forms:combatant.currentHpPlaceholder")}
+          onChange={(v) => onChange({ hp: safeParseInt(v) })}
+        />
+        <LabeledNumberInput
+          id="combatMaxHp"
+          label={t("forms:combatant.maxHp")}
+          value={newCombatant.maxHp ?? ""}
+          placeholder={t("forms:combatant.maxHpPlaceholder")}
+          onChange={(v) => onChange({ maxHp: safeParseInt(v) })}
+        />
+        <LabeledNumberInput
+          id="combatAc"
+          label={t("forms:combatant.ac")}
+          value={newCombatant.ac ?? ""}
+          placeholder={t("forms:combatant.acPlaceholder")}
+          onChange={(v) => onChange({ ac: safeParseInt(v) })}
+        />
+
+        <LabeledNumberInput
+          id="initBonus"
+          label={t("forms:combatant.initBonus")}
+          value={newCombatant.initBonus ?? ""}
+          placeholder={t("forms:combatant.initBonusPlaceholder")}
+          onChange={(v) => onChange({ initBonus: safeParseInt(v, true) })}
+        />
+      </div>
+
+      <div className="mb-4">
+        <div className="flex items-center justify-between mb-2">
+          <label className="text-sm font-medium text-slate-300">
+            {t("forms:combatant.initiative")}
+            {totalCount > 0 && (
+              <span className="ml-2 text-blue-400 text-xs">
+                {t("forms:combatant.initiativeHint", {
+                  count: totalCount,
+                  range: getLetterRange(),
+                })}
+              </span>
+            )}
+          </label>
         </div>
-      </button>
 
-      <div
-        className="transition-all duration-300 ease-in-out overflow-hidden"
-        style={{
-          maxHeight: isCollapsed ? "0px" : "2000px",
-          opacity: isCollapsed ? 0 : 1,
-        }}
-      >
-        {content}
+        <div className="grid grid-cols-2 md:grid-cols-4 gap-2">
+          {newCombatant.initiativeGroups.map((group, index) => (
+            <InitiativeGroupInput
+              key={group.id}
+              group={group}
+              index={index}
+              initBonus={newCombatant.initBonus}
+              canRemove={newCombatant.initiativeGroups.length > 1}
+              onChange={onUpdateInitiativeGroup}
+              onRemove={onRemoveInitiativeGroup}
+            />
+          ))}
+        </div>
+      </div>
+
+      {/* Add to Fight Checkbox - Only show in player/group modes */}
+      {(isButtonVisible("savePlayer") || isButtonVisible("park")) && (
+        <div className="mb-4">
+          <label className="flex items-center gap-2 text-slate-300 cursor-pointer">
+            <input
+              type="checkbox"
+              checked={addToFightChecked}
+              onChange={(e) => onAddToFightChange(e.target.checked)}
+              className="w-4 h-4 rounded border-slate-600 bg-slate-700 text-lime-600 focus:ring-lime-600 focus:ring-offset-slate-800"
+            />
+            <span className="text-sm font-medium">
+              {t("forms:combatant.addToFight")}
+            </span>
+          </label>
+        </div>
+      )}
+
+      {/* Add Another Checkbox - Show in all modes */}
+      <div className="mb-4">
+        <label className="flex items-center gap-2 text-slate-300 cursor-pointer">
+          <input
+            type="checkbox"
+            checked={addAnotherChecked}
+            onChange={(e) => onAddAnotherChange(e.target.checked)}
+            className="w-4 h-4 rounded border-slate-600 bg-slate-700 text-lime-600 focus:ring-lime-600 focus:ring-offset-slate-800"
+          />
+          <span className="text-sm font-medium">
+            {t("forms:combatant.addAnother")}
+          </span>
+        </label>
+      </div>
+
+      <div className="grid grid-cols-2 md:flex gap-2 md:gap-3 mt-4">
+        {isButtonVisible("fight") && (
+          <button
+            onClick={onSubmit}
+            className="disabled:pointer-events-none disabled:opacity-50 bg-lime-600 hover:bg-lime-700 text-white px-4 py-3 rounded flex items-center justify-center gap-2 transition"
+            title={t("forms:combatant.actions.fight")}
+            disabled={isNewCombatantInvalid(newCombatant)}
+          >
+            <Sword className="w-5 h-5" />
+            <span className="hidden md:inline">
+              {t("forms:combatant.actions.fight")}
+            </span>
+          </button>
+        )}
+        {isButtonVisible("park") && (
+          <button
+            onClick={onAddGroup}
+            className="disabled:pointer-events-none disabled:opacity-50 bg-sky-600 hover:bg-sky-500 text-white px-4 py-3 rounded flex items-center justify-center gap-2 transition"
+            title={t("forms:combatant.actions.park")}
+            disabled={isNewCombatantInvalid(newCombatant)}
+          >
+            <CircleParking className="w-5 h-5" />
+            <span className="hidden md:inline">
+              {t("forms:combatant.actions.park")}
+            </span>
+          </button>
+        )}
+        {isButtonVisible("savePlayer") && (
+          <button
+            onClick={onSaveAsPlayer}
+            className="disabled:pointer-events-none disabled:opacity-50 bg-purple-600 hover:bg-purple-700 text-white px-4 py-3 rounded flex items-center justify-center gap-2 transition"
+            title={t("forms:combatant.actions.savePlayer")}
+            disabled={isNewCombatantInvalid(newCombatant)}
+          >
+            <Save className="w-5 h-5" />
+            <span className="hidden md:inline">
+              {t("forms:combatant.actions.savePlayer")}
+            </span>
+          </button>
+        )}
+        {isButtonVisible("addToLibrary") && (
+          <button
+            onClick={onAddToLibrary}
+            className="disabled:pointer-events-none disabled:opacity-50 bg-amber-600 hover:bg-amber-700 text-white px-4 py-3 rounded flex items-center justify-center gap-2 transition"
+            title={t("forms:combatant.actions.addToLibrary")}
+            disabled={isNewCombatantInvalid(newCombatant)}
+          >
+            <Save className="w-5 h-5" />
+            <span className="hidden md:inline">
+              {t("forms:combatant.actions.addToLibrary")}
+            </span>
+          </button>
+        )}
+        {isButtonVisible("addInitGroup") && (
+          <button
+            onClick={onAddInitiativeGroup}
+            className="bg-slate-600 hover:bg-slate-700 text-white px-4 py-3 rounded flex items-center justify-center gap-2 transition"
+            title={t("forms:combatant.actions.addInitGroup")}
+          >
+            <Dice3 className="w-5 h-5" />
+            <span className="hidden md:inline">
+              {t("forms:combatant.actions.addInitGroup")}
+            </span>
+          </button>
+        )}
       </div>
     </div>
   );
+
+  return content;
 }

--- a/src/components/CombatForm/AddCombatantModal.tsx
+++ b/src/components/CombatForm/AddCombatantModal.tsx
@@ -1,19 +1,28 @@
-import { X } from "lucide-react";
+import { X, BookOpen } from "lucide-react";
 import { useTranslation } from "react-i18next";
 import type { InitiativeGroup, NewCombatant, SearchResult } from "../../types";
 import AddCombatantForm from "./AddCombatantForm";
 
 export type AddCombatantModalMode = "player" | "group" | "fight";
 
-type ButtonType = "fight" | "park" | "savePlayer" | "addToLibrary" | "addInitGroup";
+type ButtonType =
+  | "fight"
+  | "park"
+  | "savePlayer"
+  | "addToLibrary"
+  | "addInitGroup";
 
 type Props = {
   isOpen: boolean;
   mode: AddCombatantModalMode;
   onClose: () => void;
-  value: NewCombatant;
+  newCombatant: NewCombatant;
   stagedFrom?: string;
   totalCount: number;
+  addToFightChecked: boolean;
+  onAddToFightChange: (checked: boolean) => void;
+  addAnotherChecked: boolean;
+  onAddAnotherChange: (checked: boolean) => void;
   onChange: (patch: Partial<NewCombatant>) => void;
   onSubmit: () => void;
   onAddGroup: () => void;
@@ -27,21 +36,26 @@ type Props = {
   onSearchMonsters: (searchName: string) => Promise<SearchResult[]>;
   onSelectSearchResult: (searchResult: SearchResult) => void;
   onAddToLibrary: () => void;
+  onOpenLibrary: () => void;
 };
 
 const BUTTON_MODE_MAP: Record<AddCombatantModalMode, ButtonType[]> = {
   player: ["savePlayer", "addToLibrary", "addInitGroup"],
   group: ["park", "addToLibrary", "addInitGroup"],
-  fight: ["fight", "addToLibrary", "addInitGroup"]
+  fight: ["fight", "addToLibrary", "addInitGroup"],
 };
 
 export default function AddCombatantModal({
   isOpen,
   mode,
   onClose,
-  value,
+  newCombatant,
   stagedFrom,
   totalCount,
+  addToFightChecked,
+  onAddToFightChange,
+  addAnotherChecked,
+  onAddAnotherChange,
   onChange,
   onSubmit,
   onAddGroup,
@@ -51,14 +65,16 @@ export default function AddCombatantModal({
   onUpdateInitiativeGroup,
   onSearchMonsters,
   onSelectSearchResult,
-  onAddToLibrary
+  onAddToLibrary,
+  onOpenLibrary,
 }: Props) {
   const { t } = useTranslation("forms");
 
   if (!isOpen) return null;
 
   const visibleButtons = BUTTON_MODE_MAP[mode];
-  const modalTitle = t(`forms:combatant.modalTitle.${mode}`);
+  const titleKey = newCombatant.name ? `${mode}-edit` : mode;
+  const modalTitle = t(`forms:combatant.modalTitle.${titleKey}`);
 
   return (
     <>
@@ -76,22 +92,34 @@ export default function AddCombatantModal({
             <h2 className="text-xl md:text-2xl font-bold text-white">
               {modalTitle}
             </h2>
-            <button
-              onClick={onClose}
-              className="text-slate-400 hover:text-white transition"
-            >
-              <X className="w-6 h-6" />
-            </button>
+            <div className="flex items-center gap-2">
+              <button
+                onClick={onOpenLibrary}
+                className="bg-amber-600 hover:bg-amber-700 text-white p-2 rounded transition"
+                title={t("forms:combatant.actions.library")}
+              >
+                <BookOpen className="w-5 h-5" />
+              </button>
+              <button
+                onClick={onClose}
+                className="text-slate-400 hover:text-white transition"
+              >
+                <X className="w-6 h-6" />
+              </button>
+            </div>
           </div>
 
           {/* Content */}
           <div className="overflow-y-auto p-4 md:p-6">
             <AddCombatantForm
-              value={value}
+              newCombatant={newCombatant}
               stagedFrom={stagedFrom}
               totalCount={totalCount}
-              inModal={true}
               visibleButtons={visibleButtons}
+              addToFightChecked={addToFightChecked}
+              onAddToFightChange={onAddToFightChange}
+              addAnotherChecked={addAnotherChecked}
+              onAddAnotherChange={onAddAnotherChange}
               onChange={onChange}
               onSubmit={onSubmit}
               onAddGroup={onAddGroup}

--- a/src/components/MonsterLibrary/MonsterEditModal.tsx
+++ b/src/components/MonsterLibrary/MonsterEditModal.tsx
@@ -79,12 +79,12 @@ export default function MonsterEditModal({
     <>
       {/* Backdrop */}
       <div
-        className="fixed inset-0 bg-black/50 backdrop-blur-sm z-[30]"
+        className="fixed inset-0 bg-black/50 backdrop-blur-sm z-40"
         onClick={onCancel}
       />
 
       {/* Modal */}
-      <div className="fixed inset-0 z-[30] flex items-center justify-center p-4">
+      <div className="fixed inset-0 z-40 flex items-center justify-center p-4">
         <div className="bg-slate-800 rounded-lg border border-slate-700 max-w-2xl w-full max-h-[90vh] overflow-y-auto">
           {/* Header */}
           <div className="flex items-center justify-between p-4 md:p-6 border-b border-slate-700 sticky top-0 bg-slate-800 z-10">

--- a/src/components/MonsterLibrary/MonsterLibraryModal.tsx
+++ b/src/components/MonsterLibrary/MonsterLibraryModal.tsx
@@ -86,12 +86,12 @@ export default function MonsterLibraryModal({
     <>
       {/* Backdrop */}
       <div
-        className="!mt-0 fixed inset-0 bg-black/50 backdrop-blur-sm z-20"
+        className="!mt-0 fixed inset-0 bg-black/50 backdrop-blur-sm z-30"
         onClick={onClose}
       />
 
       {/* Modal */}
-      <div className="fixed inset-0 z-20 flex items-center justify-center p-4">
+      <div className="fixed inset-0 z-30 flex items-center justify-center p-4">
         <div className="bg-slate-800 rounded-lg border border-slate-700 max-w-4xl w-full max-h-[90vh] shadow-xl flex flex-col">
           {/* Header */}
           <div className="flex items-center justify-between p-4 md:p-6 border-b border-slate-700">

--- a/src/components/SaveBar.tsx
+++ b/src/components/SaveBar.tsx
@@ -2,7 +2,6 @@ import { useTranslation } from "react-i18next";
 import LabeledTextInput from "./common/LabeledTextInput";
 import LanguageSwitcher from "./common/LanguageSwitcher";
 import { useEffect } from "react";
-import { BookOpen } from "lucide-react";
 
 type Props = {
   name: string;
@@ -11,7 +10,6 @@ type Props = {
   onBack: () => void;
   onSave: () => void;
   hasChanges: boolean;
-  onOpenLibrary?: () => void;
 };
 
 export default function SaveBar({
@@ -21,7 +19,6 @@ export default function SaveBar({
   onBack,
   onSave,
   hasChanges,
-  onOpenLibrary,
 }: Props) {
   useEffect(() => {
     const handleKeyDown = (event: KeyboardEvent) => {
@@ -78,15 +75,6 @@ export default function SaveBar({
           >
             {t("common:actions.save")}
           </button>
-          {onOpenLibrary && (
-            <button
-              onClick={onOpenLibrary}
-              className="bg-amber-600 hover:bg-amber-700 text-white px-4 py-2 rounded transition font-medium flex items-center justify-center h-[38px]"
-              title={t("common:actions.library")}
-            >
-              <BookOpen className="w-5 h-5" />
-            </button>
-          )}
           <LanguageSwitcher />
         </div>
       </div>

--- a/src/components/TurnControls/FocusModeToggle.tsx
+++ b/src/components/TurnControls/FocusModeToggle.tsx
@@ -16,9 +16,7 @@ export default function FocusModeToggle({ isFocusMode, onToggle }: Props) {
   return (
     <button
       onClick={onToggle}
-      className={`bg-slate-800 rounded-lg px-4 py-4 border border-slate-700 flex items-center justify-center transition hover:bg-slate-700 ${
-        isFocusMode ? "text-amber-400" : "text-purple-400"
-      }`}
+      className={`bg-slate-800 rounded-lg px-4 py-4 border border-slate-700 flex items-center justify-center transition hover:bg-slate-700 text-yellow-400`}
       title={title}
     >
       {isFocusMode ? (

--- a/src/components/TurnControls/TurnControls.tsx
+++ b/src/components/TurnControls/TurnControls.tsx
@@ -63,7 +63,7 @@ export default function TurnControls({
         </button>
         <button
           onClick={onOpenAddModal}
-          className="bg-lime-600 hover:bg-lime-700 text-white px-4 py-3 md:py-2 rounded transition flex items-center justify-center"
+          className="bg-yellow-600 hover:bg-yellow-700 text-white px-4 py-3 md:py-2 rounded transition flex items-center justify-center"
           title={t("combat:turn.addToFight")}
         >
           <Plus className="w-5 h-5" />

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -24,7 +24,6 @@ export const DEFAULT_NEW_COMBATANT: Omit<NewCombatant, 'id'> = {
   imageUrl: "",
   externalResourceUrl: "",
   notes: "",
-  addToFight: false,
   templateOrigin: {
     origin: 'no_template',
     id: ''

--- a/src/i18n/locales/en/combat.json
+++ b/src/i18n/locales/en/combat.json
@@ -28,7 +28,7 @@
     }
   },
   "groups": {
-    "title": "Groups",
+    "title": "Fighting groups",
     "removeAll": "Remove All",
     "count": "{{count}} combatant",
     "count_plural": "{{count}} combatants"

--- a/src/i18n/locales/en/forms.json
+++ b/src/i18n/locales/en/forms.json
@@ -29,12 +29,22 @@
     "colorPicker": "Color",
     "stagedFrom": "Staged from",
     "addToFight": "Add to fight",
+    "addAnother": "Add an other",
     "actions": {
-      "fight": "Fight",
-      "park": "Park group",
-      "savePlayer": "Save player",
-      "addToLibrary": "Add to library",
-      "addInitGroup": "Add init group"
+      "fight": "Add to fight",
+      "park": "Submit",
+      "savePlayer": "Save",
+      "addToLibrary": "Save in library",
+      "addInitGroup": "Add init group",
+      "library": "Open the library"
+    },
+    "modalTitle": {
+      "player": "Create a player",
+      "player-edit": "Edit a player",
+      "group": "Create a group",
+      "group-edit": "Edit a group",
+      "fight": "Add a combatant",
+      "fight-edit": "Edit a combatant"
     },
     "searchMonster": "Search API for this creature",
     "enterNameToSearch": "Enter a name to search",

--- a/src/i18n/locales/fr/combat.json
+++ b/src/i18n/locales/fr/combat.json
@@ -29,7 +29,7 @@
     }
   },
   "groups": {
-    "title": "Groupes",
+    "title": "Groupes en combat",
     "removeAll": "Tout retirer",
     "count": "{{count}} combattant",
     "count_plural": "{{count}} combattants"

--- a/src/i18n/locales/fr/forms.json
+++ b/src/i18n/locales/fr/forms.json
@@ -29,17 +29,22 @@
     "colorPicker": "Couleur",
     "stagedFrom": "Chargé depuis",
     "addToFight": "Ajouter au combat",
+    "addAnother": "En ajouter un autre",
     "actions": {
-      "fight": "Combat !",
-      "park": "Mettre de coté",
-      "savePlayer": "Enreg. joueur",
-      "addToLibrary": "Dans la bibliothèque",
-      "addInitGroup": "Ajouter un groupe d'init"
+      "fight": "Ajouter au Combat",
+      "park": "Soumettre",
+      "savePlayer": "Sauvegarder",
+      "addToLibrary": "Sauvegarder dans la bibliothèque",
+      "addInitGroup": "Ajouter un groupe d'init",
+      "library": "Ouvrir la bibliothèque"
     },
     "modalTitle": {
       "player": "Créer un joueur",
+      "player-edit": "Editer un joueur",
       "group": "Créer un groupe",
-      "fight": "Ajouter au combat"
+      "group-edit": "Editer un groupe",
+      "fight": "Ajouter au combat",
+      "fight-edit": "Editer un combatant"
     },
     "searchMonster": "Rechercher cette créature dans l'API",
     "enterNameToSearch": "Entrer un nom pour rechercher",

--- a/src/pages/CombatTrackerPage.tsx
+++ b/src/pages/CombatTrackerPage.tsx
@@ -2,7 +2,9 @@ import { useRef, useState, useEffect } from "react";
 import { useTranslation } from "react-i18next";
 import { Sword } from "lucide-react";
 import ParkedGroupsPanel from "../components/ParkedGroups/ParkedGroupsPanel";
-import AddCombatantModal, { type AddCombatantModalMode } from "../components/CombatForm/AddCombatantModal";
+import AddCombatantModal, {
+  type AddCombatantModalMode,
+} from "../components/CombatForm/AddCombatantModal";
 import GroupsOverview from "../components/GroupsOverview/GroupsOverview";
 import TurnControls from "../components/TurnControls/TurnControls";
 import CombatLayout from "../components/CombatLayout/CombatLayout";
@@ -31,7 +33,10 @@ export default function CombatTrackerPage({ combatStateManager }: Props) {
   const [isFocusMode, setIsFocusMode] = useState(false);
   const [showLibrary, setShowLibrary] = useState(false);
   const [showAddModal, setShowAddModal] = useState(false);
-  const [addModalMode, setAddModalMode] = useState<AddCombatantModalMode>("fight");
+  const [addModalMode, setAddModalMode] =
+    useState<AddCombatantModalMode>("fight");
+  const [addToFight, setAddToFight] = useState(false);
+  const [addAnOther, setAddAnOther] = useState(false);
 
   // Keyboard shortcuts for turn navigation and focus mode
   useEffect(() => {
@@ -111,9 +116,9 @@ export default function CombatTrackerPage({ combatStateManager }: Props) {
     combatStateManager.addCombatant({
       ...playerCombattant,
       templateOrigin: {
-        origin: 'player_library',
-        id: player.id
-      }
+        origin: "player_library",
+        id: player.id,
+      },
     });
     if (combatListRef.current) {
       combatListRef.current.scrollIntoView({
@@ -128,21 +133,32 @@ export default function CombatTrackerPage({ combatStateManager }: Props) {
     setShowAddModal(true);
   };
 
+  const handleAddToFightChange = (checked: boolean) => {
+    setAddToFight(checked);
+  };
+
+  const handleAddAnotherChange = (checked: boolean) => {
+    setAddAnOther(checked);
+  };
+
   const closeAddModal = () => {
     setShowAddModal(false);
-    // Always reset form state
+    // Always reset form state and checkboxes
     combatStateManager.updateNewCombatant(generateDefaultNewCombatant());
+    setAddToFight(false);
+    setAddAnOther(false);
   };
 
   const handleModalSubmit = () => {
-    const addToFight = combatStateManager.state.newCombatant.addToFight ?? false;
-
     switch (addModalMode) {
       case "fight":
         combatStateManager.addCombatant();
         if (combatListRef.current) {
           setTimeout(() => {
-            combatListRef.current?.scrollIntoView({ behavior: "smooth", block: "start" });
+            combatListRef.current?.scrollIntoView({
+              behavior: "smooth",
+              block: "start",
+            });
           }, 100);
         }
         break;
@@ -153,7 +169,11 @@ export default function CombatTrackerPage({ combatStateManager }: Props) {
         combatStateManager.addParkedGroup(addToFight);
         break;
     }
-    closeAddModal();
+
+    // Only close modal if "Add another" is NOT checked
+    if (!addAnOther) {
+      closeAddModal();
+    }
   };
 
   const stagedFromParkedGroups = combatStateManager.state.parkedGroups.find(
@@ -217,7 +237,6 @@ export default function CombatTrackerPage({ combatStateManager }: Props) {
                   });
                 }}
                 hasChanges={combatStateManager.hasChanges}
-                onOpenLibrary={() => setShowLibrary(true)}
               />
             </div>
           </div>
@@ -282,7 +301,7 @@ export default function CombatTrackerPage({ combatStateManager }: Props) {
 
         {combatants.length === 0 && (
           <div className="text-center text-slate-400 py-12">
-            <Sword className="text-lime-400 w-16 h-16 mx-auto mb-4 opacity-50" />
+            <Sword className="text-yellow-400 w-16 h-16 mx-auto mb-4 opacity-50" />
             <p className="text-xl">{t("combat:combatant.noCombatants")}</p>
           </div>
         )}
@@ -316,7 +335,7 @@ export default function CombatTrackerPage({ combatStateManager }: Props) {
           isOpen={showAddModal}
           mode={addModalMode}
           onClose={closeAddModal}
-          value={combatStateManager.state.newCombatant}
+          newCombatant={combatStateManager.state.newCombatant}
           stagedFrom={stagedFrom}
           totalCount={combatStateManager.getTotalCombatantCount()}
           onChange={combatStateManager.updateNewCombatant}
@@ -329,6 +348,11 @@ export default function CombatTrackerPage({ combatStateManager }: Props) {
           onSearchMonsters={combatStateManager.searchWithLibrary}
           onSelectSearchResult={combatStateManager.loadMonsterToForm}
           onAddToLibrary={combatStateManager.addCombatantToLibrary}
+          onOpenLibrary={() => setShowLibrary(true)}
+          addAnotherChecked={addAnOther}
+          addToFightChecked={addToFight}
+          onAddToFightChange={handleAddToFightChange}
+          onAddAnotherChange={handleAddAnotherChange}
         />
       </div>
     </div>

--- a/src/state.ts
+++ b/src/state.ts
@@ -110,7 +110,7 @@ const getInitialState = (): CombatState => ({
   currentTurn: 0,
   round: 1,
   parkedGroups: [],
-  newCombatant: generateDefaultNewCombatant(),
+  newCombatant: generateDefaultNewCombatant()
 });
 
 export function useCombatState(): CombatStateManager {

--- a/src/types.ts
+++ b/src/types.ts
@@ -118,7 +118,6 @@ export type TemplateOrigin = {
 export type NewCombatant = {
   templateOrigin: TemplateOrigin;
   isReference?: boolean;
-  addToFight?: boolean;
 } & CombatantTemplate<"player" | "monster">;
 export type MonsterCombatant = CombatantTemplate<"monster">;
 export type PlayerCombatant = CombatantTemplate<"player">;


### PR DESCRIPTION
This pull request introduces a modal-based workflow for adding combatants, refactors the `AddCombatantForm` to support multiple usage contexts, and improves UI consistency and internationalization for combat-related actions. The changes also add entry points for adding combatants directly from group, player, and turn controls panels.

### Modal workflow and form refactor

* Added new `AddCombatantModal` component to provide a modal interface for adding combatants, supporting different modes (player, group, fight) with context-specific button visibility. (`src/components/CombatForm/AddCombatantModal.tsx`)
* Refactored `AddCombatantForm` to accept new props for modal usage, button visibility, and checkbox controls, and to conditionally render content for modal or panel contexts. (`src/components/CombatForm/AddCombatantForm.tsx`) [[1]](diffhunk://#diff-595a32b829803b301a660ff8d992ad7b9a94d7fe25100f4b6e030ddf83646f15R12-R26) [[2]](diffhunk://#diff-595a32b829803b301a660ff8d992ad7b9a94d7fe25100f4b6e030ddf83646f15L40-R53) [[3]](diffhunk://#diff-595a32b829803b301a660ff8d992ad7b9a94d7fe25100f4b6e030ddf83646f15R68-R80) [[4]](diffhunk://#diff-595a32b829803b301a660ff8d992ad7b9a94d7fe25100f4b6e030ddf83646f15R180-R209) [[5]](diffhunk://#diff-595a32b829803b301a660ff8d992ad7b9a94d7fe25100f4b6e030ddf83646f15R221-R244) [[6]](diffhunk://#diff-595a32b829803b301a660ff8d992ad7b9a94d7fe25100f4b6e030ddf83646f15R254-R255) [[7]](diffhunk://#diff-595a32b829803b301a660ff8d992ad7b9a94d7fe25100f4b6e030ddf83646f15R266-R300)

### UI enhancements and entry points

* Added "Add" buttons to the Parked Groups, Saved Players, and Turn Controls panels, allowing users to open the add combatant modal directly from these locations. (`src/components/ParkedGroups/ParkedGroupsPanel.tsx`, `src/components/CombatForm/SavedPlayerPanel.tsx`, `src/components/TurnControls/TurnControls.tsx`) [[1]](diffhunk://#diff-a85c17e93474274c98406642cc4e118430ab1f294edaff73c1e629baa0d08ef0L2-R2) [[2]](diffhunk://#diff-a85c17e93474274c98406642cc4e118430ab1f294edaff73c1e629baa0d08ef0R11-R39) [[3]](diffhunk://#diff-4d79428277e154dc4d12b680fb7449a70bca9dcefa46b8f3b796a0d7f5706759L2-R2) [[4]](diffhunk://#diff-4d79428277e154dc4d12b680fb7449a70bca9dcefa46b8f3b796a0d7f5706759R11-R39) [[5]](diffhunk://#diff-bfd4517a35a60a8f2ce922d2b253eb904684c00ce7c180b24fd608702cf9effdR2) [[6]](diffhunk://#diff-bfd4517a35a60a8f2ce922d2b253eb904684c00ce7c180b24fd608702cf9effdR13) [[7]](diffhunk://#diff-bfd4517a35a60a8f2ce922d2b253eb904684c00ce7c180b24fd608702cf9effdR24) [[8]](diffhunk://#diff-bfd4517a35a60a8f2ce922d2b253eb904684c00ce7c180b24fd608702cf9effdR64-R70)

### Internationalization and UI consistency

* Updated English and French locale files for combat and forms to improve button labels, modal titles, and group naming for clarity and consistency. (`src/i18n/locales/en/combat.json`, `src/i18n/locales/en/forms.json`, `src/i18n/locales/fr/combat.json`) [[1]](diffhunk://#diff-1ad3f34fdde1738e870484031aaa8ddd85609539dd457c260a37735ab18130b5L31-R31) [[2]](diffhunk://#diff-b72835e227f5a9d3d94d6778c1735b10393e5caf4e9bf545faa917ec36864228R31-L36) [[3]](diffhunk://#diff-eefd04b620017544094dd947f6e1a61eb7233b2b3b5a5b10d6b18d5d1494be17L10-R11) [[4]](diffhunk://#diff-eefd04b620017544094dd947f6e1a61eb7233b2b3b5a5b10d6b18d5d1494be17L31-R32)
* Standardized button coloring and icon usage, including using cyan for focus mode and add actions, and removing conditional button text for simplified UI. (`src/components/TurnControls/FocusModeToggle.tsx`, `src/components/CombatForm/AddCombatantForm.tsx`) [[1]](diffhunk://#diff-81b16cc3b4d59617237d3975772fd6501329f0a780fc0054624c70e35348dc7dL20-R20) [[2]](diffhunk://#diff-595a32b829803b301a660ff8d992ad7b9a94d7fe25100f4b6e030ddf83646f15R221-R244)

These changes collectively streamline the combatant addition workflow, improve user experience, and lay the groundwork for further modal-based interactions.