### PR TITLE
Format special abilities from API

### DIFF
--- a/src/api/fragments.ts
+++ b/src/api/fragments.ts
@@ -19,6 +19,10 @@ export const MonsterFragments = {
           desc
           attack_bonus
         }
+        special_abilities {
+          name
+          desc
+        }
         armor_class {
           __typename
           ... on ArmorClassDex {

--- a/src/utils/monsterNotes.ts
+++ b/src/utils/monsterNotes.ts
@@ -1,4 +1,4 @@
-import type { Action, ApiMonster } from "../api/types";
+import type { Action, ApiMonster, SpecialAbility } from "../api/types";
 
 /**
  * Generate custom markdown tags for a monster action
@@ -95,10 +95,15 @@ export function generateTagsFromText(text: string): string[] {
  * damage, and saving throws. Tags are automatically rendered with icons by MarkdownRenderer.
  *
  * @param monster - Monster data from D&D 5e API
- * @returns Formatted markdown string with "## Actions" heading and tagged action descriptions
+ * @returns Formatted markdown string with sections for special abilities, actions, and conditions
  *
  * @example
  * // Returns:
+ * // ## Special Abilities
+ * //
+ * // **Keen Sight**
+ * // The roc has advantage on Wisdom (Perception) checks that rely on sight.
+ * //
  * // ## Actions
  * //
  * // **Bite** {hit: +10} {dmg: 2d10+6 piercing}
@@ -107,8 +112,28 @@ export function generateTagsFromText(text: string): string[] {
 export function formatActionsAsMarkdown(monster: ApiMonster): string {
   const parts: string[] = [];
 
+  // Add special abilities section FIRST if present
+  if (monster.special_abilities && monster.special_abilities.length > 0) {
+    parts.push("## Special Abilities", "");
+
+    // Format each special ability
+    for (const ability of monster.special_abilities) {
+      // Bold ability name
+      parts.push(`**${ability.name}**`);
+
+      // Add description on new line
+      parts.push(ability.desc);
+      parts.push(""); // Empty line between abilities
+    }
+  }
+
   // Add actions section if present
   if (monster.actions && monster.actions.length > 0) {
+    // Add separator if we already have special abilities
+    if (parts.length > 0) {
+      parts.push(""); // Extra space before new section
+    }
+
     parts.push("## Actions", "");
 
     // Format each action
@@ -134,7 +159,11 @@ export function formatActionsAsMarkdown(monster: ApiMonster): string {
 
   // Add condition immunities section if present
   if (monster.condition_immunities && monster.condition_immunities.length > 0) {
-    parts.push(""); // Empty line before section
+    // Add separator if we already have content
+    if (parts.length > 0) {
+      parts.push(""); // Extra space before new section
+    }
+
     parts.push("## Conditions", "");
 
     // Format each condition separately with its description


### PR DESCRIPTION
This pull request adds support for displaying a monster's special abilities in the formatted markdown output, alongside existing sections for actions and condition immunities. The changes ensure that special abilities are shown as their own section (if present), and improve the formatting and documentation of the markdown generation utility.

**Monster data and markdown formatting improvements:**

* Added `special_abilities` field (with `name` and `desc`) to the monster GraphQL fragment in `fragments.ts` to fetch special abilities from the API.
* Updated the markdown generation utility (`formatActionsAsMarkdown` in `monsterNotes.ts`) to include a "Special Abilities" section at the top if the monster has any special abilities, formatting each with bolded name and description.
* Improved section separation logic in the markdown generator to ensure extra spacing between "Special Abilities," "Actions," and "Conditions" sections for better readability.

**Documentation and type updates:**

* Updated the JSDoc comment for the markdown generator to reflect the new structure, including the "Special Abilities" section in the example output and return description.
* Added the `SpecialAbility` type import to `monsterNotes.ts` for type safety.