### PR TITLE
Only one quick panel open at a time

### DIFF
--- a/src/components/CombatLayout/MobileCombatLayout.tsx
+++ b/src/components/CombatLayout/MobileCombatLayout.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from "react";
+import { useState, useEffect, useCallback } from "react";
 import type { Combatant, DeathSaves } from "../../types";
 import CombatantsList from "../CombatantsList/CombatantsList";
 import CombatantDetailPanel from "../CombatantDetailPanel/CombatantDetailPanel";
@@ -27,12 +27,22 @@ export default function MobileCombatLayout({
   onUpdateInitiative,
 }: Props) {
   const [showDetail, setShowDetail] = useState(false);
+  const [openQuickButtonsId, setOpenQuickButtonsId] = useState<number | null>(null);
   const activeCombatant = combatants[currentTurn] ?? null;
 
   // Auto-close detail when turn changes
   useEffect(() => {
     setShowDetail(false);
   }, [currentTurn]);
+
+  // Auto-close QuickButtons when turn changes
+  useEffect(() => {
+    setOpenQuickButtonsId(null);
+  }, [currentTurn]);
+
+  const handleToggleQuickButtons = useCallback((id: number) => {
+    setOpenQuickButtonsId(prev => prev === id ? null : id);
+  }, []);
 
   return (
     <div className="overflow-hidden">
@@ -54,6 +64,8 @@ export default function MobileCombatLayout({
             onToggleCondition={onToggleCondition}
             onUpdateInitiative={onUpdateInitiative}
             isFocusMode={isFocusMode}
+            openQuickButtonsId={openQuickButtonsId}
+            onToggleQuickButtons={handleToggleQuickButtons}
           />
         </div>
 

--- a/src/components/CombatantsList/CombatantCard.tsx
+++ b/src/components/CombatantsList/CombatantCard.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useRef, useState, useCallback } from "react";
 import { useTranslation } from "react-i18next";
 import type { Combatant, DeathSaves } from "../../types";
 import HpBar from "./HpBar";
@@ -20,6 +20,8 @@ type Props = {
   onToggleCondition: (id: number, condition: string) => void;
   onUpdateInitiative: (id: number, newInitiative: number) => void;
   onShowDetail?: () => void;
+  isQuickButtonsOpen?: boolean;
+  onToggleQuickButtons?: (id: number) => void;
 };
 
 export default function CombatantCard({
@@ -32,6 +34,8 @@ export default function CombatantCard({
   onToggleCondition,
   onUpdateInitiative,
   onShowDetail,
+  isQuickButtonsOpen,
+  onToggleQuickButtons,
 }: Props) {
 
   const { t } = useTranslation(["combat", "common"]);
@@ -76,6 +80,10 @@ export default function CombatantCard({
   useEffect(() => {
     setInitValue(combatant.initiative.toString());
   }, [combatant.initiative]);
+
+  const handleToggleQuickButtons = useCallback(() => {
+    onToggleQuickButtons?.(combatant.id);
+  }, [onToggleQuickButtons, combatant.id]);
 
   const handleStartEdit = () => {
     setIsEditingInit(true);
@@ -133,7 +141,7 @@ export default function CombatantCard({
                     onChange={(e) => setInitValue(e.target.value)}
                     onBlur={handleSave}
                     onKeyDown={handleKeyDown}
-                    className="text-2xl md:text-3xl font-bold text-blue-400 bg-input-bg border-2 border-blue-500 rounded px-2 w-16 md:w-20 focus:outline-none"
+                    className="text-2xl md:text-3xl font-bold text-text-muted bg-input-bg border-2 border-border-secondary rounded px-2 w-16 md:w-20 focus:outline-none"
                     autoFocus
                   />
                 ) : (
@@ -141,7 +149,7 @@ export default function CombatantCard({
                     onClick={() => {
                       handleStartEdit();
                     }}
-                    className="text-2xl md:text-3xl font-bold text-blue-400 cursor-pointer hover:text-blue-300 hover:bg-blue-900/20 rounded px-2 transition-colors select-none"
+                    className="text-2xl md:text-3xl font-bold text-text-muted cursor-pointer hover:text-text-muted/80 hover:bg-blue-900/20 rounded px-2 transition-colors select-none"
                     title={t("combat:combatant.editInitiative")}
                   >
                     {combatant.initiative}
@@ -194,7 +202,7 @@ export default function CombatantCard({
                   onClick={() => {
                     onShowDetail();
                   }}
-                  className="text-blue-400 hover:text-blue-300 transition flex-shrink-0 p-1 md:hidden"
+                  className="text-text-secondary hover:text-text-secondary/60 transition flex-shrink-0 p-1 md:hidden"
                   title="View details"
                 >
                   <Eye className="w-5 h-5" />
@@ -221,6 +229,8 @@ export default function CombatantCard({
           maxHp={combatant.maxHp ?? 0}
           isActive={isActive}
           onDelta={(d) => onDeltaHp(combatant.id, d)}
+          isQuickButtonsOpen={isQuickButtonsOpen}
+          onToggleQuickButtons={handleToggleQuickButtons}
         />
       </div>
       {isDying && (

--- a/src/components/CombatantsList/CombatantsList.tsx
+++ b/src/components/CombatantsList/CombatantsList.tsx
@@ -12,6 +12,8 @@ type Props = {
   onUpdateInitiative: (id: number, newInitiative: number) => void;
   onShowDetail?: () => void;
   isFocusMode?: boolean;
+  openQuickButtonsId?: number | null;
+  onToggleQuickButtons?: (id: number) => void;
 };
 
 export default function CombatantsList({
@@ -25,6 +27,8 @@ export default function CombatantsList({
   onUpdateInitiative,
   onShowDetail,
   isFocusMode = false,
+  openQuickButtonsId,
+  onToggleQuickButtons,
 }: Props) {
   return (
     <div
@@ -44,6 +48,8 @@ export default function CombatantsList({
           onToggleCondition={onToggleCondition}
           onUpdateInitiative={onUpdateInitiative}
           onShowDetail={onShowDetail}
+          isQuickButtonsOpen={openQuickButtonsId === c.id}
+          onToggleQuickButtons={onToggleQuickButtons}
         />
       ))}
     </div>

--- a/src/components/CombatantsList/HpBar.tsx
+++ b/src/components/CombatantsList/HpBar.tsx
@@ -8,12 +8,13 @@ type Props = {
   maxHp: number;
   isActive?: boolean;
   onDelta: (delta: number) => void;
+  isQuickButtonsOpen?: boolean;
+  onToggleQuickButtons?: () => void;
 };
 
-export default function HpBar({inputId, hp, maxHp, isActive, onDelta }: Props) {
+export default function HpBar({inputId, hp, maxHp, isActive, onDelta, isQuickButtonsOpen, onToggleQuickButtons }: Props) {
   const { t } = useTranslation('combat');
   const [inputValue, setInputValue] = useState('');
-  const [showQuickButtons, setShowQuickButtons] = useState(false);
   const inputRef = useRef<HTMLInputElement>(null);
   const pct = (hp / maxHp) * 100;
 
@@ -27,9 +28,12 @@ export default function HpBar({inputId, hp, maxHp, isActive, onDelta }: Props) {
   // Auto-expand quick buttons when combatant becomes active (mobile only)
   useEffect(() => {
     if (isActive && window.innerWidth < 768) {
-      setShowQuickButtons(true);
+      onToggleQuickButtons?.();
     }
-  }, [isActive]);
+  }, [isActive, onToggleQuickButtons]);
+
+  // Use derived state for showQuickButtons
+  const showQuickButtons = isQuickButtonsOpen ?? false;
 
   const handleApply = () => {
     const value = parseInt(inputValue);
@@ -59,8 +63,8 @@ export default function HpBar({inputId, hp, maxHp, isActive, onDelta }: Props) {
         </span>
         
         <button
-          onClick={() => setShowQuickButtons(!showQuickButtons)}
-          className="md:hidden text-purple-400 hover:text-purple-300 transition flex items-center gap-1 text-sm px-2 py-1 rounded hover:bg-panel-secondary"
+          onClick={onToggleQuickButtons}
+          className="md:hidden text-text-secondary active:text-text-secondary/80 transition flex items-center gap-1 text-sm px-2 py-1 rounded"
         >
           {showQuickButtons ? <ChevronUp className="w-4 h-4" /> : <ChevronDown className="w-4 h-4" />}
           {t('combat:hpBar.quick')}


### PR DESCRIPTION
This pull request introduces a new controlled "Quick Buttons" feature for HP management in the combat UI, refactoring the previous local state approach to a parent-controlled model. It also updates styling for better visual consistency. The main changes are grouped below:

**Quick Buttons feature and state management:**

* Refactored the "Quick Buttons" logic in `HpBar`, `CombatantCard`, and `CombatantsList` to use controlled state managed by `MobileCombatLayout`, allowing only one combatant's quick buttons to be open at a time and auto-closing them when the turn changes. [[1]](diffhunk://#diff-4a2b137b083cc412829a506a3ab09f7bf91c1582491b4c5c4de1e6c96ff8f856R30-R46) [[2]](diffhunk://#diff-74df10cbe93a6ad33a4e4b706020e3d7fcf523bc852d6a9456c3014293736f92R15-R16) [[3]](diffhunk://#diff-74df10cbe93a6ad33a4e4b706020e3d7fcf523bc852d6a9456c3014293736f92R30-R31) [[4]](diffhunk://#diff-74df10cbe93a6ad33a4e4b706020e3d7fcf523bc852d6a9456c3014293736f92R51-R52) [[5]](diffhunk://#diff-da53c97d89be4dc3d1771cd54b2ef370a4bb95b9997a375cdd2aa811a49f2322R11-L16) [[6]](diffhunk://#diff-da53c97d89be4dc3d1771cd54b2ef370a4bb95b9997a375cdd2aa811a49f2322L30-R36) [[7]](diffhunk://#diff-da53c97d89be4dc3d1771cd54b2ef370a4bb95b9997a375cdd2aa811a49f2322L62-R67) [[8]](diffhunk://#diff-9eaba8a757df3f33a62f2b8cd6de3556ed09b66c4d21eba91df4e611fe7551c2R23-R24) [[9]](diffhunk://#diff-9eaba8a757df3f33a62f2b8cd6de3556ed09b66c4d21eba91df4e611fe7551c2R37-R38) [[10]](diffhunk://#diff-9eaba8a757df3f33a62f2b8cd6de3556ed09b66c4d21eba91df4e611fe7551c2R84-R87) [[11]](diffhunk://#diff-9eaba8a757df3f33a62f2b8cd6de3556ed09b66c4d21eba91df4e611fe7551c2R232-R233) [[12]](diffhunk://#diff-4a2b137b083cc412829a506a3ab09f7bf91c1582491b4c5c4de1e6c96ff8f856R67-R68)
* Added new props (`openQuickButtonsId`, `onToggleQuickButtons`, `isQuickButtonsOpen`) to relevant components to support this controlled behavior. [[1]](diffhunk://#diff-74df10cbe93a6ad33a4e4b706020e3d7fcf523bc852d6a9456c3014293736f92R15-R16) [[2]](diffhunk://#diff-9eaba8a757df3f33a62f2b8cd6de3556ed09b66c4d21eba91df4e611fe7551c2R23-R24) [[3]](diffhunk://#diff-da53c97d89be4dc3d1771cd54b2ef370a4bb95b9997a375cdd2aa811a49f2322R11-L16)

**Turn-based UI auto-closing:**

* Implemented useEffect hooks in `MobileCombatLayout` to automatically close both the detail panel and quick buttons when the turn changes, ensuring a clean and predictable user experience.

**Styling improvements:**

* Updated initiative and detail button colors in `CombatantCard` for improved consistency and accessibility, replacing hardcoded blue/purple color classes with semantic text color classes. [[1]](diffhunk://#diff-9eaba8a757df3f33a62f2b8cd6de3556ed09b66c4d21eba91df4e611fe7551c2L136-R152) [[2]](diffhunk://#diff-9eaba8a757df3f33a62f2b8cd6de3556ed09b66c4d21eba91df4e611fe7551c2L197-R205) [[3]](diffhunk://#diff-da53c97d89be4dc3d1771cd54b2ef370a4bb95b9997a375cdd2aa811a49f2322L62-R67)

**Performance and code quality:**

* Used `useCallback` for toggle handlers to avoid unnecessary re-renders and to ensure stable function references for event handlers. [[1]](diffhunk://#diff-4a2b137b083cc412829a506a3ab09f7bf91c1582491b4c5c4de1e6c96ff8f856R30-R46) [[2]](diffhunk://#diff-9eaba8a757df3f33a62f2b8cd6de3556ed09b66c4d21eba91df4e611fe7551c2R84-R87)

**Component API and prop changes:**

* Updated component signatures and prop passing throughout the combatant list and card hierarchy to support the new controlled quick buttons logic. [[1]](diffhunk://#diff-4a2b137b083cc412829a506a3ab09f7bf91c1582491b4c5c4de1e6c96ff8f856L1-R1) [[2]](diffhunk://#diff-9eaba8a757df3f33a62f2b8cd6de3556ed09b66c4d21eba91df4e611fe7551c2L1-R1) [[3]](diffhunk://#diff-74df10cbe93a6ad33a4e4b706020e3d7fcf523bc852d6a9456c3014293736f92R15-R16) [[4]](diffhunk://#diff-da53c97d89be4dc3d1771cd54b2ef370a4bb95b9997a375cdd2aa811a49f2322R11-L16)

Let me know if you want a deeper dive into any of these changes!