### PR TITLE
Use plugin to render tags

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,13 +15,15 @@
         "react-dom": "^19.1.1",
         "react-i18next": "^16.3.3",
         "react-markdown": "^10.1.0",
-        "remark-gfm": "^4.0.1"
+        "remark-gfm": "^4.0.1",
+        "unist-util-visit": "^5.0.0"
       },
       "devDependencies": {
         "@eslint/js": "^9.36.0",
         "@types/gapi": "^0.0.47",
         "@types/gapi.client.drive": "^3.0.15",
         "@types/google.accounts": "^0.0.18",
+        "@types/mdast": "^4.0.4",
         "@types/node": "^24.6.0",
         "@types/react": "^19.1.16",
         "@types/react-dom": "^19.1.9",
@@ -82,6 +84,7 @@
       "integrity": "sha512-e7jT4DxYvIDLk1ZHmU/m/mB19rex9sv0c2ftBtjSBv+kVM/902eh0fINUzD7UwLLNR+jU585GxUJ8/EBfAM5fw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.5",
@@ -1161,6 +1164,7 @@
       "integrity": "sha512-qzQZRBqkFsYyaSWXuEHc2WR9c0a0CXwiE5FWUvn7ZM+vdy1uZLfCunD38UzhuB7YN/J11ndbDBcTmOdxJo9Q7A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~7.16.0"
       }
@@ -1170,6 +1174,7 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.2.tgz",
       "integrity": "sha512-6mDvHUFSjyT2B2yeNx2nUgMxh9LtOWvkhIU3uePn2I2oyNymUAX1NIsdgviM4CH+JSrp2D2hsMvJOkxY+0wNRA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.0.2"
       }
@@ -1236,6 +1241,7 @@
       "integrity": "sha512-6m1I5RmHBGTnUGS113G04DMu3CpSdxCAU/UvtjNWL4Nuf3MW9tQhiJqRlHzChIkhy6kZSAQmc+I1bcGjE3yNKg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.46.3",
         "@typescript-eslint/types": "8.46.3",
@@ -1494,6 +1500,7 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1724,6 +1731,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.8.19",
         "caniuse-lite": "^1.0.30001751",
@@ -2105,6 +2113,7 @@
       "integrity": "sha512-iy2GE3MHrYTL5lrCtMZ0X1KLEKKUjmK0kzwcnefhR66txcEmXZD2YWgR5GNdcEwkNx3a0siYkSvl0vIC+Svjmg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -2664,6 +2673,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.27.6"
       },
@@ -2885,6 +2895,7 @@
       "integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "jiti": "bin/jiti.js"
       }
@@ -4512,6 +4523,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -4711,6 +4723,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.0.tgz",
       "integrity": "sha512-tmbWg6W31tQLeB5cdIBOicJDJRR2KzXsV7uSK9iNfLWQ5bIZfxuPEHp7M8wiHyHnn0DD1i7w3Zmin0FtkrwoCQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -5359,6 +5372,7 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -5446,6 +5460,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "devOptional": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -5664,6 +5679,7 @@
       "integrity": "sha512-eSiiRJmovt8qDJkGyZuLnbxAOAdie6NCmmd0NkTC0RJI9duiSBTfr8X2mBYJOUFzxQa2USaHmL99J9uMxkjCyw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@oxc-project/runtime": "0.92.0",
         "fdir": "^6.5.0",
@@ -5758,6 +5774,7 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },

--- a/package.json
+++ b/package.json
@@ -17,13 +17,15 @@
     "react-dom": "^19.1.1",
     "react-i18next": "^16.3.3",
     "react-markdown": "^10.1.0",
-    "remark-gfm": "^4.0.1"
+    "remark-gfm": "^4.0.1",
+    "unist-util-visit": "^5.0.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.36.0",
     "@types/gapi": "^0.0.47",
     "@types/gapi.client.drive": "^3.0.15",
     "@types/google.accounts": "^0.0.18",
+    "@types/mdast": "^4.0.4",
     "@types/node": "^24.6.0",
     "@types/react": "^19.1.16",
     "@types/react-dom": "^19.1.9",

--- a/src/components/common/mardown/remarkCustomTags.ts
+++ b/src/components/common/mardown/remarkCustomTags.ts
@@ -1,0 +1,174 @@
+import { visit, SKIP } from 'unist-util-visit';
+import type { Plugin } from 'unified';
+import type { Root, PhrasingContent, Parent, InlineCode } from 'mdast';
+import {
+  EDITOR_TAGS,
+  DICE_NOTATION_REGEX,
+  DICE_NOTATION_TEST_REGEX,
+  MARKDOWN_LINK_PROTECTION_REGEX,
+  CUSTOM_TAG_PREFIX,
+  DICE_NOTATION_PREFIX,
+  TAG_COMPONENT_SEPARATOR
+} from '../../../constants';
+
+/**
+ * Remark plugin that processes custom D&D tags and dice notation
+ *
+ * How it works:
+ * 1. Works at parent level to reconstruct text that markdown parser splits across nodes
+ * 2. Decodes base64-encoded links (protected by MarkdownRenderer preprocessing)
+ * 3. Processes custom tags ({spell: ...}, {dmg: ...}, etc.) into inlineCode nodes
+ * 4. Processes dice notation (2d6+3) into inlineCode nodes
+ *
+ * Note: Runs BEFORE remarkGfm, but base64 encoding is still needed because
+ * the core markdown parser extracts links before ANY plugins run.
+ */
+export const remarkCustomTags: Plugin<[], Root> = () => {
+  return (tree) => {
+    // Visit parent nodes that can contain phrasing content
+    visit(tree, (node) => {
+      // Type guard: Only process nodes that are Parent types (have children)
+      if (!('children' in node) || !Array.isArray(node.children) || node.children.length === 0) {
+        return;
+      }
+
+      const parentNode = node as Parent;
+
+      // Reconstruct text from all text children
+      let fullText = '';
+      let hasTextChildren = false;
+
+      for (const child of parentNode.children) {
+        if (child.type === 'text') {
+          fullText += child.value;
+          hasTextChildren = true;
+        } else if (child.type === 'inlineCode' || child.type === 'code') {
+          // Skip code blocks - don't process tags inside code
+          return;
+        }
+      }
+
+      // If no text content, skip this node
+      if (!hasTextChildren || fullText.length === 0) return;
+
+      // Decode base64-encoded links back to markdown link syntax
+      // MarkdownRenderer uses base64 to protect [text](url) from being extracted by markdown parser
+      fullText = fullText.replace(MARKDOWN_LINK_PROTECTION_REGEX, (_match, base64Data) => {
+        try {
+          return atob(base64Data);
+        } catch (e) {
+          console.error('[remarkCustomTags] Failed to decode base64:', base64Data, e);
+          return _match; // Return original if decode fails
+        }
+      });
+
+      // Check if this text contains any tags
+      let hasTags = false;
+      for (const tag of EDITOR_TAGS) {
+        if (tag.pattern.test(fullText)) {
+          hasTags = true;
+          break;
+        }
+      }
+
+      if (!hasTags && !DICE_NOTATION_TEST_REGEX.test(fullText)) {
+        // No tags or dice notation found, skip
+        return;
+      }
+
+      // Process the full reconstructed text
+      let segments: (string | PhrasingContent)[] = [fullText];
+
+      // Step 1: Process custom tags ({spell: content}, {dmg: content}, etc.)
+      EDITOR_TAGS.forEach((tag) => {
+        segments = segments.flatMap((segment): (string | PhrasingContent)[] => {
+          // Only process string segments
+          if (typeof segment !== 'string') return [segment];
+
+          const parts: (string | InlineCode)[] = [];
+          let lastIndex = 0;
+
+          // CRITICAL: Reset lastIndex to 0 before each matchAll to avoid stale state
+          tag.pattern.lastIndex = 0;
+          const matches = [...segment.matchAll(tag.pattern)];
+
+          // If no matches, return segment unchanged
+          if (matches.length === 0) return [segment];
+
+          // Process each match
+          matches.forEach((match) => {
+            const matchIndex = match.index!;
+            const content = match[1].trim();
+
+            // Add text before match
+            if (matchIndex > lastIndex) {
+              parts.push(segment.substring(lastIndex, matchIndex));
+            }
+
+            // Extract tag type from pattern (e.g., 'spell' from /\{spell:\s*([^}]+)\}/gi)
+            const tagTypeMatch = tag.pattern.source.match(/\{(\w+):/);
+            const tagType = tagTypeMatch ? tagTypeMatch[1] : 'unknown';
+
+            // Create inlineCode node with special prefix that we can detect and render
+            // ReactMarkdown DOES know how to render inlineCode nodes
+            const codeNode: InlineCode = {
+              type: 'inlineCode',
+              value: `${CUSTOM_TAG_PREFIX}${TAG_COMPONENT_SEPARATOR}${tagType}${TAG_COMPONENT_SEPARATOR}${content}${TAG_COMPONENT_SEPARATOR}${tag.className}`,
+            };
+
+            parts.push(codeNode);
+            lastIndex = matchIndex + match[0].length;
+          });
+
+          // Add remaining text after last match
+          if (lastIndex < segment.length) {
+            parts.push(segment.substring(lastIndex));
+          }
+
+          return parts;
+        });
+      });
+
+      // Step 2: Process dice notation (2d6+3, 1d20, etc.)
+      segments = segments.flatMap((segment): (string | PhrasingContent)[] => {
+        // Only process string segments
+        if (typeof segment !== 'string') return [segment];
+
+        const parts = segment.split(DICE_NOTATION_REGEX);
+        return parts.map((part): string | InlineCode => {
+          if (DICE_NOTATION_TEST_REGEX.test(part)) {
+            // Use inlineCode node with special prefix
+            const diceNode: InlineCode = {
+              type: 'inlineCode',
+              value: `${DICE_NOTATION_PREFIX}${TAG_COMPONENT_SEPARATOR}${part}`,
+            };
+            return diceNode;
+          }
+          return part;
+        });
+      });
+
+      // Step 3: Convert remaining strings to text nodes
+      const finalSegments: PhrasingContent[] = [];
+      segments.forEach((segment) => {
+        if (typeof segment === 'string') {
+          // Only add non-empty text nodes
+          if (segment.length > 0) {
+            finalSegments.push({
+              type: 'text',
+              value: segment
+            });
+          }
+        } else {
+          finalSegments.push(segment);
+        }
+      });
+
+      // Step 4: Replace parent's children with processed segments
+      parentNode.children = finalSegments;
+
+      // Don't visit children since we just replaced them
+      return SKIP;
+    });
+  };
+};

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -254,3 +254,28 @@ export const EDITOR_TAGS: EditorTag[] = [
 export const DICE_NOTATION_REGEX = /(\d+d\d+(?:\s*[+-]\s*\d+)?)/gi;
 export const DICE_NOTATION_TEST_REGEX = /^\d+d\d+(?:\s*[+-]\s*\d+)?$/i;
 
+// ============================================================
+// Markdown Rendering Configuration
+// ============================================================
+
+// Base64 Link Protection
+// These constants are used to encode/decode markdown links inside custom tags
+// to prevent the markdown parser from extracting them before our plugin runs.
+// Example: {spell: [Fireball](url)} → {spell: MDLINK<base64>ENDLINK}
+export const MARKDOWN_LINK_PROTECTION_PREFIX = 'MDLINK';
+export const MARKDOWN_LINK_PROTECTION_SUFFIX = 'ENDLINK';
+export const MARKDOWN_LINK_PROTECTION_REGEX = /MDLINK([A-Za-z0-9+/=]+)ENDLINK/g;
+
+// Regex to detect custom tags containing markdown links
+// Matches: {spell: [Fireball](url)}, {dmg: [text](url) more text}
+export const MARKDOWN_LINK_IN_TAG_REGEX = /\{([a-z]+):\s*\[([^\]]+)\]\(([^)]+)\)([^}]*)\}/gi;
+
+// Encoding prefixes for processed content in AST nodes
+// These prefixes identify custom tags and dice notation in inlineCode nodes
+export const CUSTOM_TAG_PREFIX = 'CUSTOMTAG';
+export const DICE_NOTATION_PREFIX = 'DICE';
+export const TAG_COMPONENT_SEPARATOR = '::';
+
+// Regex to parse markdown link notation [text](url) within tag content
+export const MARKDOWN_LINK_NOTATION_REGEX = /^\[([^\]]+)\]\(([^)]+)\)$/;
+


### PR DESCRIPTION
This pull request refactors the markdown rendering system to robustly support custom D&D tags and dice notation, especially when they contain markdown links. The main change is moving the processing logic out of the React component and into a dedicated remark plugin, which improves maintainability and correctness. It also introduces a link protection mechanism to ensure links inside custom tags are parsed correctly.

**Markdown rendering improvements:**

* Added a new `remarkCustomTags` plugin (`src/components/common/mardown/remarkCustomTags.ts`) to process custom tags and dice notation, reconstructing text nodes for accurate parsing and converting them into inline code nodes for React rendering.
* Implemented a base64 link protection scheme in `src/constants.ts` and `MarkdownRenderer.tsx` to prevent the markdown parser from extracting links inside custom tags before the plugin runs, ensuring correct rendering of links within tags. [[1]](diffhunk://#diff-8fa4b52909f895e8cda060d2035234e0a42ca2c7d3f8f8de1b35a056537bf199R257-R281) [[2]](diffhunk://#diff-e3ab09b49883e5d1deeacd461b51f9579b797758d4611abffd86c8340d676eb4L1-R70)

**Refactoring and code simplification:**

* Removed the `processChildren` function from `MarkdownRenderer.tsx`, delegating all tag and dice notation processing to the remark plugin, which simplifies the React component and reduces complexity.
* Updated the rendering logic for headings, paragraphs, lists, code blocks, tables, and emphasis in `MarkdownRenderer.tsx` to directly render children, relying on the AST structure produced by the plugin. [[1]](diffhunk://#diff-e3ab09b49883e5d1deeacd461b51f9579b797758d4611abffd86c8340d676eb4L1-R70) [[2]](diffhunk://#diff-e3ab09b49883e5d1deeacd461b51f9579b797758d4611abffd86c8340d676eb4L145-R83) [[3]](diffhunk://#diff-e3ab09b49883e5d1deeacd461b51f9579b797758d4611abffd86c8340d676eb4L157-R170) [[4]](diffhunk://#diff-e3ab09b49883e5d1deeacd461b51f9579b797758d4611abffd86c8340d676eb4L192-R220)

**Dependency updates:**

* Added `unist-util-visit` and `@types/mdast` to `package.json` to support AST traversal and type safety for the new remark plugin.