### PR TITLE
Fix bold, italic and regular md syntax not working in same custom tag line 

### DIFF
--- a/src/components/common/mardown/remarkCustomTags.ts
+++ b/src/components/common/mardown/remarkCustomTags.ts
@@ -15,10 +15,11 @@ import {
  * Remark plugin that processes custom D&D tags and dice notation
  *
  * How it works:
- * 1. Works at parent level to reconstruct text that markdown parser splits across nodes
- * 2. Decodes base64-encoded links (protected by MarkdownRenderer preprocessing)
- * 3. Processes custom tags ({spell: ...}, {dmg: ...}, etc.) into inlineCode nodes
- * 4. Processes dice notation (2d6+3) into inlineCode nodes
+ * 1. Iterates through each child of parent nodes individually
+ * 2. Preserves non-text nodes (strong, emphasis, link, etc.) as-is
+ * 3. For text nodes: decodes base64-encoded links (protected by MarkdownRenderer preprocessing)
+ * 4. Processes custom tags ({spell: ...}, {dmg: ...}, etc.) into inlineCode nodes
+ * 5. Processes dice notation (2d6+3) into inlineCode nodes
  *
  * Note: Runs BEFORE remarkGfm, but base64 encoding is still needed because
  * the core markdown parser extracts links before ANY plugins run.
@@ -34,138 +35,135 @@ export const remarkCustomTags: Plugin<[], Root> = () => {
 
       const parentNode = node as Parent;
 
-      // Reconstruct text from all text children
-      let fullText = '';
-      let hasTextChildren = false;
-
+      // Check if any child contains code (skip entire parent if so)
       for (const child of parentNode.children) {
-        if (child.type === 'text') {
-          fullText += child.value;
-          hasTextChildren = true;
-        } else if (child.type === 'inlineCode' || child.type === 'code') {
+        if (child.type === 'inlineCode' || child.type === 'code') {
           // Skip code blocks - don't process tags inside code
           return;
         }
       }
 
-      // If no text content, skip this node
-      if (!hasTextChildren || fullText.length === 0) return;
+      // Check if there are any text children to process
+      const hasTextChildren = parentNode.children.some(
+        (child) => child.type === 'text' && 'value' in child
+      );
 
-      // Decode base64-encoded links back to markdown link syntax
-      // MarkdownRenderer uses base64 to protect [text](url) from being extracted by markdown parser
-      fullText = fullText.replace(MARKDOWN_LINK_PROTECTION_REGEX, (_match, base64Data) => {
-        try {
-          return atob(base64Data);
-        } catch (e) {
-          console.error('[remarkCustomTags] Failed to decode base64:', base64Data, e);
-          return _match; // Return original if decode fails
-        }
-      });
-
-      // Check if this text contains any tags
-      let hasTags = false;
-      for (const tag of EDITOR_TAGS) {
-        if (tag.pattern.test(fullText)) {
-          hasTags = true;
-          break;
-        }
-      }
-
-      if (!hasTags && !DICE_NOTATION_TEST_REGEX.test(fullText)) {
-        // No tags or dice notation found, skip
+      // If no text children, let visit continue to nested nodes
+      if (!hasTextChildren) {
         return;
       }
 
-      // Process the full reconstructed text
-      let segments: (string | PhrasingContent)[] = [fullText];
+      // Process each child individually, preserving non-text nodes (strong, emphasis, link, etc.)
+      const newChildren: PhrasingContent[] = [];
 
-      // Step 1: Process custom tags ({spell: content}, {dmg: content}, etc.)
-      EDITOR_TAGS.forEach((tag) => {
+      for (const child of parentNode.children) {
+        // Only process text nodes - preserve everything else (strong, emphasis, link, etc.)
+        if (child.type !== 'text' || !('value' in child)) {
+          newChildren.push(child as PhrasingContent);
+          continue;
+        }
+
+        // Process this text node for custom tags and dice notation
+        let text = child.value as string;
+
+        // Decode base64-encoded links back to markdown link syntax
+        // MarkdownRenderer uses base64 to protect [text](url) from being extracted by markdown parser
+        text = text.replace(MARKDOWN_LINK_PROTECTION_REGEX, (_match, base64Data) => {
+          try {
+            return atob(base64Data);
+          } catch (e) {
+            console.error('[remarkCustomTags] Failed to decode base64:', base64Data, e);
+            return _match; // Return original if decode fails
+          }
+        });
+
+        // Process this text segment for tags and dice notation
+        let segments: (string | PhrasingContent)[] = [text];
+
+        // Step 1: Process custom tags ({spell: content}, {dmg: content}, etc.)
+        EDITOR_TAGS.forEach((tag) => {
+          segments = segments.flatMap((segment): (string | PhrasingContent)[] => {
+            // Only process string segments
+            if (typeof segment !== 'string') return [segment];
+
+            const parts: (string | InlineCode)[] = [];
+            let lastIndex = 0;
+
+            // CRITICAL: Reset lastIndex to 0 before each matchAll to avoid stale state
+            tag.pattern.lastIndex = 0;
+            const matches = [...segment.matchAll(tag.pattern)];
+
+            // If no matches, return segment unchanged
+            if (matches.length === 0) return [segment];
+
+            // Process each match
+            matches.forEach((match) => {
+              const matchIndex = match.index!;
+              const content = match[1].trim();
+
+              // Add text before match
+              if (matchIndex > lastIndex) {
+                parts.push(segment.substring(lastIndex, matchIndex));
+              }
+
+              // Extract tag type from pattern (e.g., 'spell' from /\{spell:\s*([^}]+)\}/gi)
+              const tagTypeMatch = tag.pattern.source.match(/\{(\w+):/);
+              const tagType = tagTypeMatch ? tagTypeMatch[1] : 'unknown';
+
+              // Create inlineCode node with special prefix that we can detect and render
+              // ReactMarkdown DOES know how to render inlineCode nodes
+              const codeNode: InlineCode = {
+                type: 'inlineCode',
+                value: `${CUSTOM_TAG_PREFIX}${TAG_COMPONENT_SEPARATOR}${tagType}${TAG_COMPONENT_SEPARATOR}${content}${TAG_COMPONENT_SEPARATOR}${tag.className}`,
+              };
+
+              parts.push(codeNode);
+              lastIndex = matchIndex + match[0].length;
+            });
+
+            // Add remaining text after last match
+            if (lastIndex < segment.length) {
+              parts.push(segment.substring(lastIndex));
+            }
+
+            return parts;
+          });
+        });
+
+        // Step 2: Process dice notation (2d6+3, 1d20, etc.)
         segments = segments.flatMap((segment): (string | PhrasingContent)[] => {
           // Only process string segments
           if (typeof segment !== 'string') return [segment];
 
-          const parts: (string | InlineCode)[] = [];
-          let lastIndex = 0;
-
-          // CRITICAL: Reset lastIndex to 0 before each matchAll to avoid stale state
-          tag.pattern.lastIndex = 0;
-          const matches = [...segment.matchAll(tag.pattern)];
-
-          // If no matches, return segment unchanged
-          if (matches.length === 0) return [segment];
-
-          // Process each match
-          matches.forEach((match) => {
-            const matchIndex = match.index!;
-            const content = match[1].trim();
-
-            // Add text before match
-            if (matchIndex > lastIndex) {
-              parts.push(segment.substring(lastIndex, matchIndex));
+          const parts = segment.split(DICE_NOTATION_REGEX);
+          return parts.map((part): string | InlineCode => {
+            if (DICE_NOTATION_TEST_REGEX.test(part)) {
+              // Use inlineCode node with special prefix
+              const diceNode: InlineCode = {
+                type: 'inlineCode',
+                value: `${DICE_NOTATION_PREFIX}${TAG_COMPONENT_SEPARATOR}${part}`,
+              };
+              return diceNode;
             }
-
-            // Extract tag type from pattern (e.g., 'spell' from /\{spell:\s*([^}]+)\}/gi)
-            const tagTypeMatch = tag.pattern.source.match(/\{(\w+):/);
-            const tagType = tagTypeMatch ? tagTypeMatch[1] : 'unknown';
-
-            // Create inlineCode node with special prefix that we can detect and render
-            // ReactMarkdown DOES know how to render inlineCode nodes
-            const codeNode: InlineCode = {
-              type: 'inlineCode',
-              value: `${CUSTOM_TAG_PREFIX}${TAG_COMPONENT_SEPARATOR}${tagType}${TAG_COMPONENT_SEPARATOR}${content}${TAG_COMPONENT_SEPARATOR}${tag.className}`,
-            };
-
-            parts.push(codeNode);
-            lastIndex = matchIndex + match[0].length;
+            return part;
           });
-
-          // Add remaining text after last match
-          if (lastIndex < segment.length) {
-            parts.push(segment.substring(lastIndex));
-          }
-
-          return parts;
         });
-      });
 
-      // Step 2: Process dice notation (2d6+3, 1d20, etc.)
-      segments = segments.flatMap((segment): (string | PhrasingContent)[] => {
-        // Only process string segments
-        if (typeof segment !== 'string') return [segment];
-
-        const parts = segment.split(DICE_NOTATION_REGEX);
-        return parts.map((part): string | InlineCode => {
-          if (DICE_NOTATION_TEST_REGEX.test(part)) {
-            // Use inlineCode node with special prefix
-            const diceNode: InlineCode = {
-              type: 'inlineCode',
-              value: `${DICE_NOTATION_PREFIX}${TAG_COMPONENT_SEPARATOR}${part}`,
-            };
-            return diceNode;
+        // Step 3: Add processed segments to newChildren
+        segments.forEach((segment) => {
+          if (typeof segment === 'string') {
+            // Only add non-empty text nodes
+            if (segment.length > 0) {
+              newChildren.push({ type: 'text', value: segment });
+            }
+          } else {
+            newChildren.push(segment);
           }
-          return part;
         });
-      });
+      }
 
-      // Step 3: Convert remaining strings to text nodes
-      const finalSegments: PhrasingContent[] = [];
-      segments.forEach((segment) => {
-        if (typeof segment === 'string') {
-          // Only add non-empty text nodes
-          if (segment.length > 0) {
-            finalSegments.push({
-              type: 'text',
-              value: segment
-            });
-          }
-        } else {
-          finalSegments.push(segment);
-        }
-      });
-
-      // Step 4: Replace parent's children with processed segments
-      parentNode.children = finalSegments;
+      // Step 4: Replace parent's children with processed children
+      parentNode.children = newChildren;
 
       // Don't visit children since we just replaced them
       return SKIP;


### PR DESCRIPTION
This pull request refactors the `remarkCustomTags` plugin to improve how it processes custom tags and dice notation in markdown. The main change is that it now processes each text child individually, preserving non-text formatting nodes (like bold, italics, and links) instead of flattening all text into a single string. This ensures better compatibility with complex markdown structures and avoids disrupting formatting.

**Improvements to custom tag and dice notation processing:**

* The plugin now iterates through each child of parent nodes, processing only text nodes for custom tags and dice notation, while preserving non-text nodes (such as `strong`, `emphasis`, and `link`) as-is. [[1]](diffhunk://#diff-8076c8498b975f2a91fd7acc6fc5b67ebd87f2fe3d7c8f53f621a505392f9320L18-R22) [[2]](diffhunk://#diff-8076c8498b975f2a91fd7acc6fc5b67ebd87f2fe3d7c8f53f621a505392f9320L37-R71)
* Instead of reconstructing and re-parsing all text content at the parent level, the plugin processes each text node individually, which prevents loss of formatting and improves accuracy. [[1]](diffhunk://#diff-8076c8498b975f2a91fd7acc6fc5b67ebd87f2fe3d7c8f53f621a505392f9320L37-R71) [[2]](diffhunk://#diff-8076c8498b975f2a91fd7acc6fc5b67ebd87f2fe3d7c8f53f621a505392f9320L65-R81)

**Code simplification and robustness:**

* The logic for checking and processing tags and dice notation has been updated to operate per text node, removing unnecessary checks and making the code easier to maintain.
* The replacement of parent node children is now handled by accumulating processed nodes in a new array, ensuring only modified nodes are replaced and all formatting is preserved.