### PR TITLE
Make the combat card all selectable

### DIFF
--- a/src/components/CombatLayout/CombatLayout.tsx
+++ b/src/components/CombatLayout/CombatLayout.tsx
@@ -1,3 +1,4 @@
+import { useState, useEffect, useCallback } from "react";
 import DesktopCombatLayout from "./DesktopCombatLayout";
 import MobileCombatLayout from "./MobileCombatLayout";
 import type { Combatant, DeathSaves } from "../../types";
@@ -28,6 +29,40 @@ export default function CombatLayout({
   onUpdateInitiative,
 }: Props) {
   const isDesktop = useMediaQuery("(min-width: 768px)");
+  const [selectedCombatantId, setSelectedCombatantId] = useState<number | null>(null);
+  const [showMobileDetail, setShowMobileDetail] = useState(false);
+
+  const activeCombatant = combatants[currentTurn] ?? null;
+
+  // Auto-select new active combatant when turn changes
+  useEffect(() => {
+    if (activeCombatant && isFocusMode) {
+      setSelectedCombatantId(activeCombatant.id);
+    }
+    // Close mobile detail panel on turn change
+    setShowMobileDetail(false);
+  }, [currentTurn, activeCombatant, isFocusMode]);
+
+  // Reset selection when focus mode is disabled
+  useEffect(() => {
+    if (!isFocusMode) {
+      setSelectedCombatantId(null);
+      setShowMobileDetail(false);
+    }
+  }, [isFocusMode]);
+
+  const handleSelectCombatant = useCallback((id: number) => {
+    setSelectedCombatantId(prev => prev === id ? null : id);
+  }, []);
+
+  const handleMobileSelectCombatant = useCallback((id: number) => {
+    setSelectedCombatantId(id);
+    setShowMobileDetail(true);
+  }, []);
+
+  const handleCloseMobileDetail = useCallback(() => {
+    setShowMobileDetail(false);
+  }, []);
 
   if (isDesktop) {
     return (
@@ -42,6 +77,8 @@ export default function CombatLayout({
         onDeathSaves={onDeathSaves}
         onToggleCondition={onToggleCondition}
         onUpdateInitiative={onUpdateInitiative}
+        selectedCombatantId={selectedCombatantId}
+        onSelectCombatant={handleSelectCombatant}
       />
     );
   }
@@ -58,6 +95,10 @@ export default function CombatLayout({
       onDeathSaves={onDeathSaves}
       onToggleCondition={onToggleCondition}
       onUpdateInitiative={onUpdateInitiative}
+      selectedCombatantId={selectedCombatantId}
+      onSelectCombatant={handleMobileSelectCombatant}
+      showDetail={showMobileDetail}
+      onCloseDetail={handleCloseMobileDetail}
     />
   );
 }

--- a/src/components/CombatLayout/DesktopCombatLayout.tsx
+++ b/src/components/CombatLayout/DesktopCombatLayout.tsx
@@ -14,6 +14,8 @@ type Props = {
   onDeathSaves: (id: number, type: keyof DeathSaves, value: number) => void;
   onToggleCondition: (id: number, condition: string) => void;
   onUpdateInitiative: (id: number, newInitiative: number) => void;
+  selectedCombatantId: number | null;
+  onSelectCombatant: (id: number) => void;
 };
 
 export default function DesktopCombatLayout({
@@ -27,13 +29,17 @@ export default function DesktopCombatLayout({
   onDeathSaves,
   onToggleCondition,
   onUpdateInitiative,
+  selectedCombatantId,
+  onSelectCombatant,
 }: Props) {
-  const activeCombatant = combatants[currentTurn] ?? null;
+  const selectedCombatant = selectedCombatantId !== null
+    ? combatants.find(c => c.id === selectedCombatantId) ?? null
+    : null;
 
   return (
     <div className="flex gap-4 h-full">
       {/* Left side: CombatantsList */}
-      <div className={activeCombatant && isFocusMode ? "flex-1 h-full" : "w-full"}>
+      <div className={selectedCombatant && isFocusMode ? "flex-1 h-full" : "w-full"}>
         <CombatantsList
           combatants={combatants}
           currentTurn={currentTurn}
@@ -45,14 +51,16 @@ export default function DesktopCombatLayout({
           onToggleCondition={onToggleCondition}
           onUpdateInitiative={onUpdateInitiative}
           isFocusMode={isFocusMode}
+          selectedCombatantId={selectedCombatantId}
+          onSelectCombatant={onSelectCombatant}
         />
       </div>
 
-      {/* Right side: Detail panel - only render if active combatant exists AND in focus mode */}
-      {activeCombatant && isFocusMode && (
+      {/* Right side: Detail panel - only render if a combatant is selected AND in focus mode */}
+      {selectedCombatant && isFocusMode && (
         <div className="flex-1 flex flex-col overflow-y-auto">
           <div className="my-auto w-full">
-            <CombatantDetailPanel combatant={activeCombatant} />
+            <CombatantDetailPanel combatant={selectedCombatant} />
           </div>
         </div>
       )}

--- a/src/components/CombatLayout/MobileCombatLayout.tsx
+++ b/src/components/CombatLayout/MobileCombatLayout.tsx
@@ -14,6 +14,10 @@ type Props = {
   onDeathSaves: (id: number, type: keyof DeathSaves, value: number) => void;
   onToggleCondition: (id: number, condition: string) => void;
   onUpdateInitiative: (id: number, newInitiative: number) => void;
+  selectedCombatantId: number | null;
+  onSelectCombatant: (id: number) => void;
+  showDetail: boolean;
+  onCloseDetail: () => void;
 };
 
 export default function MobileCombatLayout({
@@ -27,15 +31,16 @@ export default function MobileCombatLayout({
   onDeathSaves,
   onToggleCondition,
   onUpdateInitiative,
+  selectedCombatantId,
+  onSelectCombatant,
+  showDetail,
+  onCloseDetail,
 }: Props) {
-  const [showDetail, setShowDetail] = useState(false);
   const [openQuickButtonsId, setOpenQuickButtonsId] = useState<number | null>(null);
-  const activeCombatant = combatants[currentTurn] ?? null;
 
-  // Auto-close detail when turn changes
-  useEffect(() => {
-    setShowDetail(false);
-  }, [currentTurn]);
+  const selectedCombatant = selectedCombatantId !== null
+    ? combatants.find(c => c.id === selectedCombatantId) ?? null
+    : null;
 
   // Auto-close QuickButtons when turn changes
   useEffect(() => {
@@ -60,7 +65,6 @@ export default function MobileCombatLayout({
             currentTurn={currentTurn}
             shouldScrollToActive={shouldScrollToActive}
             onClearScrollFlag={onClearScrollFlag}
-            onShowDetail={() => setShowDetail(true)}
             onRemove={onRemove}
             onDeltaHp={onDeltaHp}
             onDeathSaves={onDeathSaves}
@@ -69,16 +73,18 @@ export default function MobileCombatLayout({
             isFocusMode={isFocusMode}
             openQuickButtonsId={openQuickButtonsId}
             onToggleQuickButtons={handleToggleQuickButtons}
+            selectedCombatantId={selectedCombatantId}
+            onSelectCombatant={onSelectCombatant}
           />
         </div>
 
         {/* Slide 2: Detail panel */}
         <div className="w-full flex-shrink-0 flex flex-col overflow-y-auto">
-          {activeCombatant && (
+          {selectedCombatant && (
             <div className="my-auto w-full">
               <CombatantDetailPanel
-                combatant={activeCombatant}
-                onClose={() => setShowDetail(false)}
+                combatant={selectedCombatant}
+                onClose={onCloseDetail}
               />
             </div>
           )}

--- a/src/components/CombatantDetailPanel/CombatantDetailPanel.tsx
+++ b/src/components/CombatantDetailPanel/CombatantDetailPanel.tsx
@@ -4,6 +4,7 @@ import CombatantAvatar from "../common/CombatantAvatar";
 import { AbilityScore } from "../common/AbilityScore";
 import { useTranslation } from "react-i18next";
 import MarkdownRenderer from "../common/mardown/MarkdownRenderer";
+import { getHpColorClass } from "../../utils/utils";
 
 type Props = {
   combatant: Combatant;
@@ -63,7 +64,7 @@ export default function CombatantDetailPanel({ combatant, onClose }: Props) {
             <Heart className="w-3 h-3 md:w-4 md:h-4" />
             {t("combat:combatant.details.hitPoints")}
           </div>
-          <div className="text-2xl md:text-3xl font-bold text-green-400">
+          <div className={`text-2xl md:text-3xl font-bold ${getHpColorClass(combatant.hp ?? 0, combatant.maxHp ?? 1)}`}>
             {combatant.hp ?? 0} / {combatant.maxHp ?? 0}
           </div>
         </div>

--- a/src/components/CombatantsList/CombatantCard.tsx
+++ b/src/components/CombatantsList/CombatantCard.tsx
@@ -12,6 +12,8 @@ import { useConfirmationDialog } from "../../hooks/useConfirmationDialog";
 type Props = {
   combatant: Combatant;
   isActive: boolean;
+  isSelected?: boolean;
+  showEyeButton?: boolean;
   shouldScroll: boolean;
   onScrollComplete: () => void;
   onRemove: (id: number) => void;
@@ -27,6 +29,8 @@ type Props = {
 export default function CombatantCard({
   combatant,
   isActive,
+  isSelected = false,
+  showEyeButton = false,
   shouldScroll,
   onScrollComplete,
   onRemove,
@@ -112,12 +116,17 @@ export default function CombatantCard({
     }
   };
 
+  // Selection visual only shows when selected but NOT active (active takes priority)
+  const showSelectionVisual = isSelected && !isActive;
+
   return (
     <div
       ref={cardRef}
       className={`bg-panel-bg rounded-lg p-4 md:p-6 border-2 transition ${
         isActive
           ? "border-yellow-500 shadow-lg shadow-yellow-500/20"
+          : showSelectionVisual
+          ? "border-selection shadow-lg shadow-selection/20"
           : "border-border-primary"
       }`}
       style={{ borderLeftWidth: "6px", borderLeftColor: combatant.color }}
@@ -190,12 +199,16 @@ export default function CombatantCard({
               </div>
             </div>
             <div className="flex gap-2">
-              {isActive && onShowDetail && (
+              {showEyeButton && onShowDetail && (
                 <button
                   onClick={() => {
                     onShowDetail();
                   }}
-                  className="text-text-secondary hover:text-text-secondary/60 transition flex-shrink-0 p-1 md:hidden"
+                  className={`transition flex-shrink-0 p-1 ${
+                    isSelected
+                      ? "text-selection hover:text-selection/60"
+                      : "text-text-secondary hover:text-text-secondary/60"
+                  }`}
                   title="View details"
                 >
                   <Eye className="w-5 h-5" />

--- a/src/components/CombatantsList/CombatantsList.tsx
+++ b/src/components/CombatantsList/CombatantsList.tsx
@@ -11,10 +11,11 @@ type Props = {
   onDeathSaves: (id: number, type: keyof DeathSaves, value: number) => void;
   onToggleCondition: (id: number, condition: string) => void;
   onUpdateInitiative: (id: number, newInitiative: number) => void;
-  onShowDetail?: () => void;
   isFocusMode?: boolean;
   openQuickButtonsId?: number | null;
   onToggleQuickButtons?: (id: number) => void;
+  selectedCombatantId?: number | null;
+  onSelectCombatant?: (id: number) => void;
 };
 
 export default function CombatantsList({
@@ -27,10 +28,11 @@ export default function CombatantsList({
   onDeathSaves,
   onToggleCondition,
   onUpdateInitiative,
-  onShowDetail,
   isFocusMode = false,
   openQuickButtonsId,
   onToggleQuickButtons,
+  selectedCombatantId,
+  onSelectCombatant,
 }: Props) {
   return (
     <div
@@ -43,6 +45,8 @@ export default function CombatantsList({
           key={c.id}
           combatant={c}
           isActive={index === currentTurn}
+          isSelected={c.id === selectedCombatantId}
+          showEyeButton={isFocusMode}
           shouldScroll={index === currentTurn && shouldScrollToActive}
           onScrollComplete={onClearScrollFlag}
           onRemove={onRemove}
@@ -50,7 +54,7 @@ export default function CombatantsList({
           onDeathSaves={onDeathSaves}
           onToggleCondition={onToggleCondition}
           onUpdateInitiative={onUpdateInitiative}
-          onShowDetail={onShowDetail}
+          onShowDetail={onSelectCombatant ? () => onSelectCombatant(c.id) : undefined}
           isQuickButtonsOpen={openQuickButtonsId === c.id}
           onToggleQuickButtons={onToggleQuickButtons}
         />

--- a/src/components/CombatantsList/HpBar.tsx
+++ b/src/components/CombatantsList/HpBar.tsx
@@ -1,6 +1,7 @@
 import { useState, useRef, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Check, ChevronDown, ChevronUp } from 'lucide-react';
+import { getHpColorClass } from '../../utils/utils';
 
 type Props = {
   inputId: string;
@@ -74,7 +75,7 @@ export default function HpBar({inputId, hp, maxHp, isActive, onDelta, isQuickBut
       {/* HP Progress Bar */}
       <div className="w-full bg-panel-secondary rounded-full h-3 overflow-hidden mb-3">
         <div
-          className={`h-full transition-all ${pct > 50 ? 'bg-green-500' : pct > 25 ? 'bg-yellow-500' : 'bg-red-500'}`}
+          className={`h-full transition-all ${getHpColorClass(hp, maxHp, 'bg')}`}
           style={{ width: `${pct}%` }}
         />
       </div>

--- a/src/index.css
+++ b/src/index.css
@@ -18,6 +18,7 @@
     --color-accent: 156 85 45; /* Deep rust accent */
     --color-accent-hover: 125 65 35; /* Darker rust accent hover */
     --color-accent-text: 255 255 255; /* White text on accent */
+    --color-selection: 160 100 60; /* Deep terracotta selection */
   }
 
   html.light {
@@ -35,6 +36,7 @@
     --color-accent: 156 85 45; /* Deep rust accent */
     --color-accent-hover: 125 65 35; /* Darker rust accent hover */
     --color-accent-text: 255 255 255; /* White text on accent */
+    --color-selection: 160 100 60; /* Deep terracotta selection */
   }
 
   html.dark {
@@ -52,6 +54,7 @@
     --color-accent: 99 102 241; /* Vibrant indigo accent */
     --color-accent-hover: 79 70 229; /* Deeper indigo accent hover */
     --color-accent-text: 255 255 255; /* White text on accent */
+    --color-selection: 129 140 248; /* Bright indigo selection */
   }
 
   html.forest {
@@ -69,6 +72,7 @@
     --color-accent: 132 107 41; /* Golden olive accent */
     --color-accent-hover: 107 87 31; /* Darker golden olive accent hover */
     --color-accent-text: 255 255 255; /* White text on accent */
+    --color-selection: 60 120 70; /* Deep forest green selection */
   }
 
   /* Future themes can be added here */

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -134,3 +134,18 @@ export function generateDefaultNewCombatant() {
   }
 }
 
+/**
+ * Returns a color class based on HP percentage
+ * - > 50%: green
+ * - 26-50%: yellow
+ * - ≤ 25%: red
+ *
+ * Tailwind safelist: bg-green-500 bg-yellow-500 bg-red-500 text-green-400 text-yellow-400 text-red-400
+ */
+export function getHpColorClass(hp: number, maxHp: number, type: 'bg' | 'text' = 'text'): string {
+  const pct = maxHp > 0 ? (hp / maxHp) * 100 : 0;
+  const color = pct > 50 ? 'green' : pct > 25 ? 'yellow' : 'red';
+  const shade = type === 'bg' ? '500' : '400';
+  return `${type}-${color}-${shade}`;
+}
+

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -34,6 +34,7 @@ export default {
         'accent': withOpacity('--color-accent'),
         'accent-hover': withOpacity('--color-accent-hover'),
         'accent-text': withOpacity('--color-accent-text'),
+        'selection': withOpacity('--color-selection'),
       },
     },
   },


### PR DESCRIPTION
This pull request introduces a new combatant selection feature to the combat layouts, allowing users to select combatants for detail viewing independently of the active turn. It refactors both desktop and mobile layouts to support selection state, updates the combatant card visuals to indicate selection, and streamlines the detail panel logic. Additionally, new CSS variables are added for selection color theming.

**Combatant Selection & Detail Panel Logic**

* Added selection state management (`selectedCombatantId`) and handlers to `CombatLayout`, automatically selecting the active combatant in focus mode and resetting selection when focus mode is disabled. Selection state is passed down to both desktop and mobile layouts, enabling detail panels to show the selected combatant rather than always the active one. [[1]](diffhunk://#diff-a90bfa68100807be12493365f65d8284b0564f6ec6ae216c478883bfedde69f2R32-R65) [[2]](diffhunk://#diff-a90bfa68100807be12493365f65d8284b0564f6ec6ae216c478883bfedde69f2R80-R81) [[3]](diffhunk://#diff-a90bfa68100807be12493365f65d8284b0564f6ec6ae216c478883bfedde69f2R98-R101)
* Updated `DesktopCombatLayout` and `MobileCombatLayout` to receive selection props, use the selected combatant for detail panels, and handle selection via callbacks. Mobile layout now also receives props for detail panel visibility and closing. [[1]](diffhunk://#diff-c37dba506b9385e69d894a7e82bedefd5d73aed3d4205c1945439ccddbc5a020R17-R18) [[2]](diffhunk://#diff-c37dba506b9385e69d894a7e82bedefd5d73aed3d4205c1945439ccddbc5a020R32-R42) [[3]](diffhunk://#diff-c37dba506b9385e69d894a7e82bedefd5d73aed3d4205c1945439ccddbc5a020R54-R63) [[4]](diffhunk://#diff-4a2b137b083cc412829a506a3ab09f7bf91c1582491b4c5c4de1e6c96ff8f856R17-R20) [[5]](diffhunk://#diff-4a2b137b083cc412829a506a3ab09f7bf91c1582491b4c5c4de1e6c96ff8f856R34-R43) [[6]](diffhunk://#diff-4a2b137b083cc412829a506a3ab09f7bf91c1582491b4c5c4de1e6c96ff8f856R76-R87)

**Combatants List & Card Enhancements**

* Refactored `CombatantsList` and `CombatantCard` to support selection: cards receive `isSelected` and `showEyeButton` props, render selection visuals, and trigger selection via the eye button. The eye button now uses selection color for visual feedback. [[1]](diffhunk://#diff-74df10cbe93a6ad33a4e4b706020e3d7fcf523bc852d6a9456c3014293736f92L14-R18) [[2]](diffhunk://#diff-74df10cbe93a6ad33a4e4b706020e3d7fcf523bc852d6a9456c3014293736f92L30-R35) [[3]](diffhunk://#diff-74df10cbe93a6ad33a4e4b706020e3d7fcf523bc852d6a9456c3014293736f92R48-R57) [[4]](diffhunk://#diff-9eaba8a757df3f33a62f2b8cd6de3556ed09b66c4d21eba91df4e611fe7551c2R15-R16) [[5]](diffhunk://#diff-9eaba8a757df3f33a62f2b8cd6de3556ed09b66c4d21eba91df4e611fe7551c2R32-R33) [[6]](diffhunk://#diff-9eaba8a757df3f33a62f2b8cd6de3556ed09b66c4d21eba91df4e611fe7551c2R119-R129) [[7]](diffhunk://#diff-9eaba8a757df3f33a62f2b8cd6de3556ed09b66c4d21eba91df4e611fe7551c2L193-R211)

**Theming**

* Added new CSS variables for selection color to all themes in `index.css`, enabling consistent selection highlight styling across light, dark, and custom themes. [[1]](diffhunk://#diff-85da366246340e911d7a0eb9153e64137a1b31f0686c74d9aef9ae4f032cb09eR21) [[2]](diffhunk://#diff-85da366246340e911d7a0eb9153e64137a1b31f0686c74d9aef9ae4f032cb09eR39) [[3]](diffhunk://#diff-85da366246340e911d7a0eb9153e64137a1b31f0686c74d9aef9ae4f032cb09eR57) [[4]](diffhunk://#diff-85da366246340e911d7a0eb9153e64137a1b31f0686c74d9aef9ae4f032cb09eR75)