### PR TITLE
Dispay used localStorage in settings

### DIFF
--- a/src/components/Settings/SettingsModal.tsx
+++ b/src/components/Settings/SettingsModal.tsx
@@ -8,6 +8,7 @@ import LanguageSwitcher from "../common/LanguageSwitcher";
 import SyncButton from "../SyncButton";
 import type { SyncApi } from "../../api/sync/types";
 import type { CombatantIdentifierType } from "../../types";
+import { getLocalStorageSize } from "../../utils/utils";
 
 type Props = {
   isOpen: boolean;
@@ -41,6 +42,8 @@ export default function SettingsModal({ isOpen, syncApi, onClose }: Props) {
     },
     [updateSettings],
   );
+
+  const storageSize = getLocalStorageSize();
 
   if (!isOpen) return null;
 
@@ -160,6 +163,16 @@ export default function SettingsModal({ isOpen, syncApi, onClose }: Props) {
                   {t("common:settings.combatantIdentifier.numbers")}
                 </button>
               </div>
+            </div>
+
+            {/* Storage Section */}
+            <div className="space-y-3 pt-3 border-t border-border-primary">
+              <h3 className="text-lg font-semibold text-text-secondary">
+                {t("common:settings.storage.title")}
+              </h3>
+              <p className="text-sm text-text-muted">
+                {t("common:settings.storage.used", { size: storageSize })}
+              </p>
             </div>
 
             {/* Google Drive Section */}

--- a/src/i18n/locales/en/common.json
+++ b/src/i18n/locales/en/common.json
@@ -131,6 +131,10 @@
       "letters": "Letters (A, B, C...)",
       "numbers": "Numbers (1, 2, 3...)"
     },
+    "storage": {
+      "title": "Local Storage",
+      "used": "Data stored locally: {{size}}"
+    },
     "googleDrive": {
       "title": "Sync Your Combats Across All Your Devices",
       "connect": "Sign in with Google",

--- a/src/i18n/locales/fr/common.json
+++ b/src/i18n/locales/fr/common.json
@@ -131,6 +131,10 @@
       "letters": "Lettres (A, B, C...)",
       "numbers": "Nombres (1, 2, 3...)"
     },
+    "storage": {
+      "title": "Stockage local",
+      "used": "Données stockées localement : {{size}}"
+    },
     "googleDrive": {
       "title": "Synchronisez vos combats sur tous vos appareils",
       "connect": "Connectez-vous avec Google",

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -256,6 +256,13 @@ export function buildPlayerCombatantsForFight(
   return result.sort((a, b) => b.initiative - a.initiative);
 }
 
+export function getLocalStorageSize(): string {
+  const totalMB = Object.keys(localStorage)
+    .map((k) => ((localStorage.getItem(k) ?? "").length * 2) / 1024 / 1024)
+    .reduce((a, b) => a + b, 0);
+  return `${totalMB.toFixed(2)} MB`;
+}
+
 /**
  * Returns a color class based on HP percentage
  * - > 50%: green


### PR DESCRIPTION
This pull request adds a new feature to display the total amount of local storage used by the application in the Settings modal. It introduces a utility function to calculate the storage size, updates the UI to show this information, and provides translations for the new section in both English and French.

**New Storage Usage Display in Settings:**

- **UI Update:**
  * Added a new "Local Storage" section to the `SettingsModal` that displays the amount of data stored locally, using the new `getLocalStorageSize` utility. [[1]](diffhunk://#diff-83cfddd4b11e8d8416f9a4d7e9c3fd382748c88479e76c488ef2a52f1a284abbR11) [[2]](diffhunk://#diff-83cfddd4b11e8d8416f9a4d7e9c3fd382748c88479e76c488ef2a52f1a284abbR46-R47) [[3]](diffhunk://#diff-83cfddd4b11e8d8416f9a4d7e9c3fd382748c88479e76c488ef2a52f1a284abbR168-R177)

- **Utility Function:**
  * Implemented `getLocalStorageSize` in `utils.ts` to sum the sizes of all relevant local storage keys and return the result in kilobytes. [[1]](diffhunk://#diff-5acab41990585fa68ae01ff7b2e2915628d19237840c3061b31fcadc1c0f09b8L2-R12) [[2]](diffhunk://#diff-5acab41990585fa68ae01ff7b2e2915628d19237840c3061b31fcadc1c0f09b8R277-R293)

**Internationalization:**

- **English and French Translations:**
  * Added translation strings for the new storage section in both `en/common.json` and `fr/common.json`. [[1]](diffhunk://#diff-392337a519b62796951af1c3ed5fbf31e9a3c7b00af0841359150c2ed8ba786eR134-R137) [[2]](diffhunk://#diff-c674e48cbc6fe756bca2fa8e1c7fcae91342f8ac0809a31e9c345fc581fa6598R134-R137)