### PR TITLE
+ button to add tag 

### DIFF
--- a/src/components/Campaign/BlockEditModal.tsx
+++ b/src/components/Campaign/BlockEditModal.tsx
@@ -522,6 +522,7 @@ export default function BlockEditModal({
                 ))}
                 <input
                   type="text"
+                  enterKeyHint="done"
                   value={tagDraft}
                   placeholder={
                     (formData.tags ?? []).length === 0
@@ -544,6 +545,15 @@ export default function BlockEditModal({
                   }}
                   className="flex-1 min-w-24 bg-transparent text-sm text-text-primary outline-none"
                 />
+                {tagDraft.trim() && (
+                  <button
+                    type="button"
+                    onClick={() => addTag(tagDraft)}
+                    className="text-text-muted hover:text-text-primary transition"
+                  >
+                    <Plus className="w-4 h-4" />
+                  </button>
+                )}
               </div>
               {(() => {
                 const suggestions = allTags.filter(


### PR DESCRIPTION
This pull request introduces a small usability improvement to the tag editing functionality in the `BlockEditModal` component. The main change is the addition of a button to quickly add a tag when the input is not empty, along with a minor accessibility enhancement.

UI/UX Improvements:

* Added a button next to the tag input field that appears when there is non-empty input, allowing users to add a tag with a single click. (`src/components/Campaign/BlockEditModal.tsx`)

Accessibility Enhancements:

* Set the `enterKeyHint` attribute to "done" on the tag input field to improve the experience for users on touch devices and virtual keyboards. (`src/components/Campaign/BlockEditModal.tsx`)