### PR TITLE
Focus on token

### DIFF
--- a/src/components/MapViewer/MapViewer.tsx
+++ b/src/components/MapViewer/MapViewer.tsx
@@ -1,4 +1,13 @@
 import { X } from "lucide-react";
+
+function centerCameraOn(
+  x: number,
+  y: number,
+  canvas: HTMLCanvasElement,
+  scale: number,
+) {
+  return { x: canvas.width / 2 - x * scale, y: canvas.height / 2 - y * scale };
+}
 import { useCallback, useEffect, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import PeerJSConnector from "./PeerJSConnector";
@@ -45,7 +54,7 @@ export default function MapViewer() {
   const [camera, setCamera] = useState<Camera>({ x: 0, y: 0, scale: 1 });
   const [undoStack, setUndoStack] = useState<HistoryEntry[]>([]);
   const [redoStack, setRedoStack] = useState<HistoryEntry[]>([]);
-  const [revealRadius, setRevealRadius] = useState(80);
+  const [revealRadius, setRevealRadius] = useState(145);
   const [tokenModalOpen, setTokenModalOpen] = useState(false);
   const [selectedTokenId, setSelectedTokenId] = useState<string | null>(null);
   const [portraitViewTokenId, setPortraitViewTokenId] = useState<string | null>(
@@ -85,12 +94,24 @@ export default function MapViewer() {
     setMapState,
     setPeerTransport,
     setPeerDisconnected,
+    onCenterCamera: useCallback(
+      (x: number, y: number) => {
+        const canvas = canvasRef.current;
+        if (!canvas) return;
+        setCamera((prev) => ({
+          ...prev,
+          ...centerCameraOn(x, y, canvas, prev.scale),
+        }));
+      },
+      [setCamera],
+    ),
   });
 
   const {
     draggingTokenIdRef,
     draggingTokenPosRef,
     isPointerMode,
+    isFocusMode,
     setIsPointerMode,
     handleMouseDown,
     handleMouseMove,
@@ -105,6 +126,7 @@ export default function MapViewer() {
     handleImport,
     openPlayerView,
     handleBack,
+    setIsFocusMode,
   } = useMapInteraction({
     view,
     canvasRef,
@@ -125,6 +147,9 @@ export default function MapViewer() {
       const token = mapStateRef.current!.tokens.find((t) => t.id === tokenId);
       if (token?.portraitDataUrl) setPortraitViewTokenId(tokenId);
     }, []),
+    onFocusToken: useCallback((x: number, y: number) => {
+      transportRef.current?.send({ type: "FOCUS_TOKEN", x, y });
+    }, []),
   });
 
   useMapRenderer({
@@ -139,6 +164,19 @@ export default function MapViewer() {
     revealRadiusRef,
     pingsRef,
   });
+
+  const recenterOnPlayer = useCallback(() => {
+    const tokens = mapStateRef.current!.tokens;
+    const token =
+      tokens.find((t) => t.id === "player") ?? tokens.find((t) => !t.hidden);
+    if (!token) return;
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    setCamera((prev) => ({
+      ...prev,
+      ...centerCameraOn(token.x, token.y, canvas, prev.scale),
+    }));
+  }, [mapStateRef, setCamera]);
 
   const { t } = useTranslation("map");
 
@@ -161,6 +199,9 @@ export default function MapViewer() {
         cameraScale={camera.scale}
         isPointerMode={isPointerMode}
         onTogglePointerMode={() => setIsPointerMode((v) => !v)}
+        isFocusMode={isFocusMode}
+        onToggleFocusMode={() => setIsFocusMode((v: boolean) => !v)}
+        onRecenterOnPlayer={recenterOnPlayer}
         onBack={handleBack}
         revealRadius={revealRadius}
         onRevealRadiusChange={setRevealRadius}

--- a/src/components/MapViewer/components/MapToolbar.tsx
+++ b/src/components/MapViewer/components/MapToolbar.tsx
@@ -1,6 +1,8 @@
 import {
   ArrowLeft,
   CircleUser,
+  Crosshair,
+  LocateFixed,
   MapPin,
   RotateCcw,
   Trash2,
@@ -14,6 +16,9 @@ interface Props {
   cameraScale: number;
   isPointerMode: boolean;
   onTogglePointerMode: () => void;
+  isFocusMode: boolean;
+  onToggleFocusMode: () => void;
+  onRecenterOnPlayer: () => void;
   onBack: () => void;
   revealRadius: number;
   onRevealRadiusChange: (r: number) => void;
@@ -35,6 +40,9 @@ export default function MapToolbar({
   cameraScale,
   isPointerMode,
   onTogglePointerMode,
+  isFocusMode,
+  onToggleFocusMode,
+  onRecenterOnPlayer,
   onBack,
   revealRadius,
   onRevealRadiusChange,
@@ -87,6 +95,28 @@ export default function MapToolbar({
         >
           <MapPin className="w-4 h-4" />
         </button>
+        {view === "player" && (
+          <button
+            onClick={onRecenterOnPlayer}
+            className="px-2 py-0.5 rounded text-sm transition flex items-center gap-1.5 text-text-muted hover:text-text-primary"
+            title={t("toolbar.recenterOnPlayer")}
+          >
+            <LocateFixed className="w-4 h-4" />
+          </button>
+        )}
+        {view === "dm" && (
+          <button
+            onClick={onToggleFocusMode}
+            className={`px-2 py-0.5 rounded text-sm transition flex items-center gap-1.5 ${
+              isFocusMode
+                ? "bg-amber-500 text-white"
+                : "text-text-muted hover:text-text-primary"
+            }`}
+            title={t("toolbar.focusTool")}
+          >
+            <Crosshair className="w-4 h-4" />
+          </button>
+        )}
       </div>
 
       {view === "dm" && (

--- a/src/components/MapViewer/hooks/useMapInteraction.ts
+++ b/src/components/MapViewer/hooks/useMapInteraction.ts
@@ -39,6 +39,7 @@ interface Params {
   setRedoStack: React.Dispatch<React.SetStateAction<HistoryEntry[]>>;
   setSelectedTokenId: React.Dispatch<React.SetStateAction<string | null>>;
   onTokenTap: (tokenId: string) => void;
+  onFocusToken: (x: number, y: number) => void;
 }
 
 export function useMapInteraction({
@@ -58,6 +59,7 @@ export function useMapInteraction({
   setRedoStack,
   setSelectedTokenId,
   onTokenTap,
+  onFocusToken,
 }: Params) {
   // Owned refs — internal to interaction logic
   const draggingTokenIdRef = useRef<string | null>(null);
@@ -75,6 +77,10 @@ export function useMapInteraction({
   const [isPointerMode, setIsPointerMode] = useState(false);
   const isPointerModeRef = useRef(isPointerMode);
   isPointerModeRef.current = isPointerMode;
+
+  const [isFocusMode, setIsFocusMode] = useState(false);
+  const isFocusModeRef = useRef(isFocusMode);
+  isFocusModeRef.current = isFocusMode;
 
   // --- Ping ---
 
@@ -175,6 +181,14 @@ export function useMapInteraction({
         draggingTokenIdRef.current = null;
         draggingTokenPosRef.current = null;
         isPanningRef.current = false;
+        if (isFocusModeRef.current) {
+          const token = mapStateRef.current!.tokens.find(
+            (t) => t.id === tapTokenId,
+          );
+          if (token) onFocusToken(token.x, token.y);
+          setIsFocusMode(false);
+          return;
+        }
         onTokenTap(tapTokenId);
         return;
       }
@@ -231,6 +245,7 @@ export function useMapInteraction({
     [
       emitPing,
       onTokenTap,
+      onFocusToken,
       mapStateRef,
       revealRadiusRef,
       transportRef,
@@ -617,6 +632,8 @@ export function useMapInteraction({
     draggingTokenIdRef,
     draggingTokenPosRef,
     isPointerMode,
+    isFocusMode,
+    setIsFocusMode,
     setIsPointerMode,
     handleMouseDown,
     handleMouseMove,

--- a/src/components/MapViewer/hooks/useMapSync.ts
+++ b/src/components/MapViewer/hooks/useMapSync.ts
@@ -12,6 +12,7 @@ interface Params {
   setMapState: React.Dispatch<React.SetStateAction<MapState>>;
   setPeerTransport: React.Dispatch<React.SetStateAction<MapTransport | null>>;
   setPeerDisconnected: React.Dispatch<React.SetStateAction<boolean>>;
+  onCenterCamera: (x: number, y: number) => void;
 }
 
 export function useMapSync({
@@ -24,6 +25,7 @@ export function useMapSync({
   setMapState,
   setPeerTransport,
   setPeerDisconnected,
+  onCenterCamera,
 }: Params): { synced: boolean } {
   const [synced, setSynced] = useState(view === "dm");
 
@@ -66,6 +68,9 @@ export function useMapSync({
             startedAt: performance.now(),
           });
           break;
+        case "FOCUS_TOKEN":
+          if (view === "player") onCenterCamera(msg.x, msg.y);
+          break;
       }
     });
 
@@ -95,6 +100,7 @@ export function useMapSync({
     setMapState,
     setPeerTransport,
     setPeerDisconnected,
+    onCenterCamera,
   ]);
 
   return { synced };

--- a/src/components/MapViewer/types.ts
+++ b/src/components/MapViewer/types.ts
@@ -35,7 +35,8 @@ export type MapMessage =
   | { type: "MAP_LOADED"; imageDataUrl: string }
   | { type: "REQUEST_FULL_STATE" }
   | { type: "FULL_STATE_RESPONSE"; state: MapState }
-  | { type: "POINTER_PING"; x: number; y: number };
+  | { type: "POINTER_PING"; x: number; y: number }
+  | { type: "FOCUS_TOKEN"; x: number; y: number };
 
 export interface HistoryEntry {
   tokens: Token[];

--- a/src/i18n/locales/en/map.json
+++ b/src/i18n/locales/en/map.json
@@ -4,6 +4,8 @@
     "dmView": "DM View",
     "playerView": "Player View",
     "pointerTool": "Pointer tool — click to ping a location",
+    "focusTool": "Focus — tap a token to center player view",
+    "recenterOnPlayer": "Recenter on player token",
     "importMap": "Import Map",
     "visibility": "Visibility",
     "undo": "Undo",

--- a/src/i18n/locales/fr/map.json
+++ b/src/i18n/locales/fr/map.json
@@ -4,6 +4,8 @@
     "dmView": "Vue MJ",
     "playerView": "Vue Joueur",
     "pointerTool": "Outil pointeur — cliquez pour signaler un emplacement",
+    "focusTool": "Focus — appuyez sur un pion pour centrer la vue joueur",
+    "recenterOnPlayer": "Recentrer sur le pion joueur",
     "importMap": "Importer la carte",
     "visibility": "Visibilité",
     "undo": "Annuler",


### PR DESCRIPTION
This pull request adds a new "Focus" tool for Dungeon Masters (DMs) and a "Recenter on Player" feature for players in the map viewer. The "Focus" tool allows DMs to select a token and automatically center the player's camera on it, improving navigation and session flow. The toolbar and interaction logic are updated accordingly, and relevant translations are included.

**New camera control features:**

* Added a "Focus" tool for DMs, allowing them to tap a token to center the player's view on that token. This involves new interaction logic (`isFocusMode`, `onFocusToken`) and a new message type (`FOCUS_TOKEN`) for DM-to-player communication. (`src/components/MapViewer/MapViewer.tsx` [[1]](diffhunk://#diff-196cae4265e24183d95df0f1d1730b57220be6e4ef02e6896a307e7f6d2b927fR97-R114) [[2]](diffhunk://#diff-196cae4265e24183d95df0f1d1730b57220be6e4ef02e6896a307e7f6d2b927fR150-R152) [[3]](diffhunk://#diff-e78b954930476bf9ec514d86ebe4bb452374ec3519efd137cb9a44ba189cb15dR42) [[4]](diffhunk://#diff-e78b954930476bf9ec514d86ebe4bb452374ec3519efd137cb9a44ba189cb15dR62) [[5]](diffhunk://#diff-e78b954930476bf9ec514d86ebe4bb452374ec3519efd137cb9a44ba189cb15dR81-R84) [[6]](diffhunk://#diff-e78b954930476bf9ec514d86ebe4bb452374ec3519efd137cb9a44ba189cb15dR184-R191) [[7]](diffhunk://#diff-e78b954930476bf9ec514d86ebe4bb452374ec3519efd137cb9a44ba189cb15dR248) [[8]](diffhunk://#diff-e78b954930476bf9ec514d86ebe4bb452374ec3519efd137cb9a44ba189cb15dR635-R636) [[9]](diffhunk://#diff-fd145dcdb048f27fdb75065832950229501fa565154e08aaec1614456b533886R15) [[10]](diffhunk://#diff-fd145dcdb048f27fdb75065832950229501fa565154e08aaec1614456b533886R28) [[11]](diffhunk://#diff-fd145dcdb048f27fdb75065832950229501fa565154e08aaec1614456b533886R71-R73) [[12]](diffhunk://#diff-fd145dcdb048f27fdb75065832950229501fa565154e08aaec1614456b533886R103) [[13]](diffhunk://#diff-b61c1c80cfb760454cdf704422ea2e8c4bcc22b25a597b283baf27d68387b6e1L38-R39)
* Added a "Recenter on Player" button for players, which centers the camera on the player token or the first visible token. (`src/components/MapViewer/MapViewer.tsx` [[1]](diffhunk://#diff-196cae4265e24183d95df0f1d1730b57220be6e4ef02e6896a307e7f6d2b927fR168-R180) [[2]](diffhunk://#diff-23fe16b7294fe32e1909276c22dcc3f48e5437d5620cb4cc3bc6a405299bb48bR19-R21) [[3]](diffhunk://#diff-23fe16b7294fe32e1909276c22dcc3f48e5437d5620cb4cc3bc6a405299bb48bR43-R45) [[4]](diffhunk://#diff-23fe16b7294fe32e1909276c22dcc3f48e5437d5620cb4cc3bc6a405299bb48bR98-R119)

**Toolbar and UI updates:**

* Updated the map toolbar to include new buttons for the "Focus" tool (DM view) and "Recenter on Player" (player view), with appropriate icons and tooltips. (`src/components/MapViewer/components/MapToolbar.tsx` [[1]](diffhunk://#diff-23fe16b7294fe32e1909276c22dcc3f48e5437d5620cb4cc3bc6a405299bb48bR4-R5) [[2]](diffhunk://#diff-23fe16b7294fe32e1909276c22dcc3f48e5437d5620cb4cc3bc6a405299bb48bR19-R21) [[3]](diffhunk://#diff-23fe16b7294fe32e1909276c22dcc3f48e5437d5620cb4cc3bc6a405299bb48bR43-R45) [[4]](diffhunk://#diff-23fe16b7294fe32e1909276c22dcc3f48e5437d5620cb4cc3bc6a405299bb48bR98-R119)

**Localization:**

* Added English and French translations for the new toolbar features ("Focus" and "Recenter on Player"). (`src/i18n/locales/en/map.json` [[1]](diffhunk://#diff-c448f16f60235f6e5c78f7a5d8391a1d4682a08f2615f1042621ed1f0b497728R7-R8) `src/i18n/locales/fr/map.json` [[2]](diffhunk://#diff-5f8c08e534aa23cb6858e44df085f4c7e58047c08a8369100e18b04831715589R7-R8)

**Other adjustments:**

* Increased the default `revealRadius` from 80 to 145 for improved visibility. (`src/components/MapViewer/MapViewer.tsx` [src/components/MapViewer/MapViewer.tsxL48-R57](diffhunk://#diff-196cae4265e24183d95df0f1d1730b57220be6e4ef02e6896a307e7f6d2b927fL48-R57))