### PR TITLE
reconnect when app is bring to ront

### DIFF
--- a/src/components/MapViewer/BroadcastChannelTransport.ts
+++ b/src/components/MapViewer/BroadcastChannelTransport.ts
@@ -21,6 +21,10 @@ export class BroadcastChannelTransport implements MapTransport {
     return () => {};
   }
 
+  isConnected(): boolean {
+    return true;
+  }
+
   close() {
     this.channel.close();
   }

--- a/src/components/MapViewer/MapViewer.tsx
+++ b/src/components/MapViewer/MapViewer.tsx
@@ -49,6 +49,7 @@ export default function MapViewer() {
   );
   const [peerModalOpen, setPeerModalOpen] = useState(false);
   const [peerTransport, setPeerTransport] = useState<MapTransport | null>(null);
+  const [isPeerOnline, setIsPeerOnline] = useState(false);
   const [peerDisconnected, setPeerDisconnected] = useState(false);
   const [lastRoomCode, setLastRoomCode] = useState<string | null>(
     () => localStorage.getItem(MAP_ROOM_CODE_STORAGE_KEY) ?? null,
@@ -208,6 +209,24 @@ export default function MapViewer() {
     }
   }, [peerDisconnected, lastRoomCode, isReconnecting, reconnectToRoom]);
 
+  // Track live connection status without touching peerTransport or room state.
+  // WebRTC "close" events are unreliable when the remote tab is killed — ICE
+  // can take 30+ seconds to time out. Polling isConnected() (which checks
+  // conn.open + ICE state) catches the drop within a few seconds so the
+  // indicator clears promptly. The player can still reconnect to the same room.
+  useEffect(() => {
+    if (!peerTransport) {
+      setIsPeerOnline(false);
+      return;
+    }
+    setIsPeerOnline(true);
+    const id = setInterval(() => {
+      const next = transportRef.current?.isConnected() ?? false;
+      setIsPeerOnline((prev) => (prev === next ? prev : next));
+    }, 3000);
+    return () => clearInterval(id);
+  }, [peerTransport]);
+
   useEffect(() => {
     const handler = () => {
       if (document.visibilityState !== "visible") return;
@@ -281,8 +300,9 @@ export default function MapViewer() {
             setSelectedTokenId(mapState.tokens[0].id);
           }
         }}
-        onOpenPlayerView={openPlayerView}
         onOpenPeerModal={() => setPeerModalOpen(true)}
+        isPeerConnected={isPeerOnline}
+        isReconnecting={isReconnecting}
       />
 
       {peerModalOpen && (
@@ -298,6 +318,7 @@ export default function MapViewer() {
             setIsReconnecting(false);
             setPeerModalOpen(false);
           }}
+          onOpenLocalView={openPlayerView}
           onClose={() => setPeerModalOpen(false)}
         />
       )}

--- a/src/components/MapViewer/MapViewer.tsx
+++ b/src/components/MapViewer/MapViewer.tsx
@@ -1,18 +1,8 @@
 import { Loader2, X } from "lucide-react";
-
-function centerCameraOn(
-  x: number,
-  y: number,
-  canvas: HTMLCanvasElement,
-  scale: number,
-) {
-  return { x: canvas.width / 2 - x * scale, y: canvas.height / 2 - y * scale };
-}
-import Peer from "peerjs";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
+import { MAP_ROOM_CODE_STORAGE_KEY } from "../../constants";
 import PeerJSConnector from "./PeerJSConnector";
-import { PeerJSTransport } from "./PeerJSTransport";
 import MapToolbar from "./components/MapToolbar";
 import TokenModal from "./components/TokenModal";
 import { useMapInteraction } from "./hooks/useMapInteraction";
@@ -25,6 +15,15 @@ import type {
   MapTransport,
   PingEntry,
 } from "./types";
+
+function centerCameraOn(
+  x: number,
+  y: number,
+  canvas: HTMLCanvasElement,
+  scale: number,
+) {
+  return { x: canvas.width / 2 - x * scale, y: canvas.height / 2 - y * scale };
+}
 
 const DEFAULT_MAP_STATE: MapState = {
   imageDataUrl: null,
@@ -52,11 +51,9 @@ export default function MapViewer() {
   const [peerTransport, setPeerTransport] = useState<MapTransport | null>(null);
   const [peerDisconnected, setPeerDisconnected] = useState(false);
   const [lastRoomCode, setLastRoomCode] = useState<string | null>(
-    () => localStorage.getItem("dnd-ct:map-room-code") ?? null,
+    () => localStorage.getItem(MAP_ROOM_CODE_STORAGE_KEY) ?? null,
   );
   const [isReconnecting, setIsReconnecting] = useState(false);
-  const [showDebug, setShowDebug] = useState(false);
-  const [debugLog, setDebugLog] = useState<string[]>([]);
 
   const [mapState, setMapState] = useState<MapState>(DEFAULT_MAP_STATE);
   const [camera, setCamera] = useState<Camera>({ x: 0, y: 0, scale: 1 });
@@ -84,7 +81,9 @@ export default function MapViewer() {
   // Persist room code to localStorage so reconnect survives a page refresh
   useEffect(() => {
     if (lastRoomCode) {
-      localStorage.setItem("dnd-ct:map-room-code", lastRoomCode);
+      localStorage.setItem(MAP_ROOM_CODE_STORAGE_KEY, lastRoomCode);
+    } else {
+      localStorage.removeItem(MAP_ROOM_CODE_STORAGE_KEY);
     }
   }, [lastRoomCode]);
 
@@ -99,7 +98,7 @@ export default function MapViewer() {
     return () => window.removeEventListener("beforeunload", handler);
   }, []);
 
-  const { synced } = useMapSync({
+  const { synced, reconnectToRoom } = useMapSync({
     view,
     peerTransport,
     mapStateRef,
@@ -109,6 +108,7 @@ export default function MapViewer() {
     setMapState,
     setPeerTransport,
     setPeerDisconnected,
+    setIsReconnecting,
     onCenterCamera: useCallback(
       (x: number, y: number) => {
         const canvas = canvasRef.current;
@@ -142,6 +142,7 @@ export default function MapViewer() {
     openPlayerView,
     handleBack,
     setIsFocusMode,
+    recenterOnPlayer,
   } = useMapInteraction({
     view,
     canvasRef,
@@ -180,44 +181,7 @@ export default function MapViewer() {
     pingsRef,
   });
 
-  const recenterOnPlayer = useCallback(() => {
-    const tokens = mapStateRef.current!.tokens;
-    const token =
-      tokens.find((t) => t.id === "player") ?? tokens.find((t) => !t.hidden);
-    if (!token) return;
-    const canvas = canvasRef.current;
-    if (!canvas) return;
-    setCamera((prev) => ({
-      ...prev,
-      ...centerCameraOn(token.x, token.y, canvas, prev.scale),
-    }));
-  }, [mapStateRef, setCamera]);
-
-  const reconnectToRoom = useCallback((roomCode: string) => {
-    console.log(`DEBUG ==> reconnectToRoom called, roomCode=${roomCode}`);
-    setIsReconnecting(true);
-    const peer = new Peer();
-    peer.on("open", (id) => {
-      console.log(
-        `DEBUG ==> [reconnect] peer open id=${id}, connecting to room=${roomCode}`,
-      );
-      const conn = peer.connect(roomCode);
-      conn.on("open", () => {
-        console.log(`DEBUG ==> [reconnect] conn open — reconnected to DM`);
-        setPeerTransport(new PeerJSTransport(conn));
-        setPeerDisconnected(false);
-        setIsReconnecting(false);
-      });
-      conn.on("error", (err) => {
-        console.log(`DEBUG ==> [reconnect] conn error:`, err);
-        setIsReconnecting(false);
-      });
-    });
-    peer.on("error", (err) => {
-      console.log(`DEBUG ==> [reconnect] peer error:`, err);
-      setIsReconnecting(false);
-    });
-  }, []);
+  const { t } = useTranslation("map");
 
   // On mount: if we were previously connected as a player, auto-reconnect
   const autoReconnectAttempted = useRef(false);
@@ -225,46 +189,46 @@ export default function MapViewer() {
     if (autoReconnectAttempted.current) return;
     autoReconnectAttempted.current = true;
     if (view === "player" && lastRoomCode) {
-      console.log(`DEBUG ==> mount auto-reconnect, roomCode=${lastRoomCode}`);
       reconnectToRoom(lastRoomCode);
     }
   }, [view, lastRoomCode, reconnectToRoom]);
 
+  // Auto-reconnect whenever peerDisconnected flips to true (ICE failure, close
+  // event, or visibilitychange check). One shot per disconnection — if it fails
+  // the user sees the banner and can retry manually.
+  const hasAutoReconnectedRef = useRef(false);
+  useEffect(() => {
+    if (!peerDisconnected) {
+      hasAutoReconnectedRef.current = false;
+      return;
+    }
+    if (lastRoomCode && !isReconnecting && !hasAutoReconnectedRef.current) {
+      hasAutoReconnectedRef.current = true;
+      reconnectToRoom(lastRoomCode);
+    }
+  }, [peerDisconnected, lastRoomCode, isReconnecting, reconnectToRoom]);
+
   useEffect(() => {
     const handler = () => {
-      const transport = transportRef.current;
-      const connAlive = transport ? transport.isConnected() : false;
-      const addLog = (msg: string) => {
-        const entry = `[${new Date().toLocaleTimeString()}] ${msg}`;
-        console.log(`DEBUG ==> ${entry}`);
-        setDebugLog((prev) => [...prev.slice(-19), entry]);
-      };
-
-      addLog(
-        `vis=${document.visibilityState} alive=${connAlive} disconnected=${peerDisconnected} reconnecting=${isReconnecting}`,
-      );
-
       if (document.visibilityState !== "visible") return;
 
-      // On iOS, WebRTC connections die silently when the browser is backgrounded —
+      const transport = transportRef.current;
+
+      // On device, WebRTC connections die silently when the browser is backgrounded —
       // conn.on("close") never fires. Actively check isConnected() (checks both
       // conn.open and iceConnectionState) when coming back to the foreground.
+      // Setting peerDisconnected=true is enough — the effect below handles reconnect.
       if (
         lastRoomCode &&
         !isReconnecting &&
         transport &&
         !transport.isConnected()
       ) {
-        addLog("→ connection dead, reconnecting");
         setPeerDisconnected(true);
-        reconnectToRoom(lastRoomCode);
         return;
       }
 
       if (peerDisconnected && lastRoomCode && !isReconnecting) {
-        console.log(
-          `DEBUG ==> visibilitychange → peerDisconnected=true, triggering auto-reconnect`,
-        );
         reconnectToRoom(lastRoomCode);
       }
     };
@@ -277,8 +241,6 @@ export default function MapViewer() {
     reconnectToRoom,
     transportRef,
   ]);
-
-  const { t } = useTranslation("map");
 
   const portraitToken = portraitViewTokenId
     ? (mapState.tokens.find((t) => t.id === portraitViewTokenId) ?? null)
@@ -399,40 +361,6 @@ export default function MapViewer() {
           <p className="text-white/30 text-xs">
             {t("overlay.waitingForDmHint")}
           </p>
-        </div>
-      )}
-
-      {/* Debug toggle button */}
-      <button
-        onClick={() => setShowDebug((v) => !v)}
-        className="absolute bottom-16 right-2 z-50 bg-black/60 text-green-400 text-xs font-mono px-2 py-1 rounded border border-green-400/40"
-      >
-        DBG
-      </button>
-
-      {/* Debug panel */}
-      {showDebug && (
-        <div className="absolute bottom-24 right-2 z-50 bg-black/90 text-green-400 text-xs font-mono p-2 rounded border border-green-400/30 w-72 max-h-64 overflow-y-auto">
-          <div className="mb-1 text-green-300 font-bold">Connection state</div>
-          <div>view: {view}</div>
-          <div>transport: {peerTransport ? "connected" : "none"}</div>
-          <div>
-            isConnected:{" "}
-            {peerTransport ? String(peerTransport.isConnected()) : "n/a"}
-          </div>
-          <div>peerDisconnected: {String(peerDisconnected)}</div>
-          <div>isReconnecting: {String(isReconnecting)}</div>
-          <div>lastRoomCode: {lastRoomCode ?? "none"}</div>
-          <div className="mt-2 text-green-300 font-bold">Visibility log</div>
-          {debugLog.length === 0 ? (
-            <div className="text-green-600">no events yet</div>
-          ) : (
-            debugLog.map((entry, i) => (
-              <div key={i} className="break-all">
-                {entry}
-              </div>
-            ))
-          )}
         </div>
       )}
 

--- a/src/components/MapViewer/MapViewer.tsx
+++ b/src/components/MapViewer/MapViewer.tsx
@@ -1,4 +1,4 @@
-import { X } from "lucide-react";
+import { Loader2, X } from "lucide-react";
 
 function centerCameraOn(
   x: number,
@@ -8,9 +8,11 @@ function centerCameraOn(
 ) {
   return { x: canvas.width / 2 - x * scale, y: canvas.height / 2 - y * scale };
 }
+import Peer from "peerjs";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import PeerJSConnector from "./PeerJSConnector";
+import { PeerJSTransport } from "./PeerJSTransport";
 import MapToolbar from "./components/MapToolbar";
 import TokenModal from "./components/TokenModal";
 import { useMapInteraction } from "./hooks/useMapInteraction";
@@ -49,6 +51,12 @@ export default function MapViewer() {
   const [peerModalOpen, setPeerModalOpen] = useState(false);
   const [peerTransport, setPeerTransport] = useState<MapTransport | null>(null);
   const [peerDisconnected, setPeerDisconnected] = useState(false);
+  const [lastRoomCode, setLastRoomCode] = useState<string | null>(
+    () => localStorage.getItem("dnd-ct:map-room-code") ?? null,
+  );
+  const [isReconnecting, setIsReconnecting] = useState(false);
+  const [showDebug, setShowDebug] = useState(false);
+  const [debugLog, setDebugLog] = useState<string[]>([]);
 
   const [mapState, setMapState] = useState<MapState>(DEFAULT_MAP_STATE);
   const [camera, setCamera] = useState<Camera>({ x: 0, y: 0, scale: 1 });
@@ -72,6 +80,13 @@ export default function MapViewer() {
   const transportRef = useRef<MapTransport | null>(null);
   const pingsRef = useRef<PingEntry[]>([]);
   const nextPingIdRef = useRef(0);
+
+  // Persist room code to localStorage so reconnect survives a page refresh
+  useEffect(() => {
+    if (lastRoomCode) {
+      localStorage.setItem("dnd-ct:map-room-code", lastRoomCode);
+    }
+  }, [lastRoomCode]);
 
   // Warn before leaving when a map is loaded
   useEffect(() => {
@@ -178,6 +193,91 @@ export default function MapViewer() {
     }));
   }, [mapStateRef, setCamera]);
 
+  const reconnectToRoom = useCallback((roomCode: string) => {
+    console.log(`DEBUG ==> reconnectToRoom called, roomCode=${roomCode}`);
+    setIsReconnecting(true);
+    const peer = new Peer();
+    peer.on("open", (id) => {
+      console.log(
+        `DEBUG ==> [reconnect] peer open id=${id}, connecting to room=${roomCode}`,
+      );
+      const conn = peer.connect(roomCode);
+      conn.on("open", () => {
+        console.log(`DEBUG ==> [reconnect] conn open — reconnected to DM`);
+        setPeerTransport(new PeerJSTransport(conn));
+        setPeerDisconnected(false);
+        setIsReconnecting(false);
+      });
+      conn.on("error", (err) => {
+        console.log(`DEBUG ==> [reconnect] conn error:`, err);
+        setIsReconnecting(false);
+      });
+    });
+    peer.on("error", (err) => {
+      console.log(`DEBUG ==> [reconnect] peer error:`, err);
+      setIsReconnecting(false);
+    });
+  }, []);
+
+  // On mount: if we were previously connected as a player, auto-reconnect
+  const autoReconnectAttempted = useRef(false);
+  useEffect(() => {
+    if (autoReconnectAttempted.current) return;
+    autoReconnectAttempted.current = true;
+    if (view === "player" && lastRoomCode) {
+      console.log(`DEBUG ==> mount auto-reconnect, roomCode=${lastRoomCode}`);
+      reconnectToRoom(lastRoomCode);
+    }
+  }, [view, lastRoomCode, reconnectToRoom]);
+
+  useEffect(() => {
+    const handler = () => {
+      const transport = transportRef.current;
+      const connAlive = transport ? transport.isConnected() : false;
+      const addLog = (msg: string) => {
+        const entry = `[${new Date().toLocaleTimeString()}] ${msg}`;
+        console.log(`DEBUG ==> ${entry}`);
+        setDebugLog((prev) => [...prev.slice(-19), entry]);
+      };
+
+      addLog(
+        `vis=${document.visibilityState} alive=${connAlive} disconnected=${peerDisconnected} reconnecting=${isReconnecting}`,
+      );
+
+      if (document.visibilityState !== "visible") return;
+
+      // On iOS, WebRTC connections die silently when the browser is backgrounded —
+      // conn.on("close") never fires. Actively check isConnected() (checks both
+      // conn.open and iceConnectionState) when coming back to the foreground.
+      if (
+        lastRoomCode &&
+        !isReconnecting &&
+        transport &&
+        !transport.isConnected()
+      ) {
+        addLog("→ connection dead, reconnecting");
+        setPeerDisconnected(true);
+        reconnectToRoom(lastRoomCode);
+        return;
+      }
+
+      if (peerDisconnected && lastRoomCode && !isReconnecting) {
+        console.log(
+          `DEBUG ==> visibilitychange → peerDisconnected=true, triggering auto-reconnect`,
+        );
+        reconnectToRoom(lastRoomCode);
+      }
+    };
+    document.addEventListener("visibilitychange", handler);
+    return () => document.removeEventListener("visibilitychange", handler);
+  }, [
+    peerDisconnected,
+    lastRoomCode,
+    isReconnecting,
+    reconnectToRoom,
+    transportRef,
+  ]);
+
   const { t } = useTranslation("map");
 
   const portraitToken = portraitViewTokenId
@@ -225,12 +325,15 @@ export default function MapViewer() {
 
       {peerModalOpen && (
         <PeerJSConnector
-          onConnected={(transport, role) => {
+          onConnected={(transport, role, roomCode) => {
             setPeerTransport(transport);
             if (role === "player") {
               window.name = PLAYER_WINDOW_NAME;
               setView("player");
+              if (roomCode) setLastRoomCode(roomCode);
             }
+            setPeerDisconnected(false);
+            setIsReconnecting(false);
             setPeerModalOpen(false);
           }}
           onClose={() => setPeerModalOpen(false)}
@@ -249,27 +352,42 @@ export default function MapViewer() {
         />
       )}
 
-      {/* Disconnected banner */}
-      {peerDisconnected && (
+      {/* Disconnected / reconnecting banner */}
+      {(peerDisconnected || isReconnecting) && (
         <div className="absolute bottom-4 left-1/2 -translate-x-1/2 z-20 flex items-center gap-3 bg-panel-bg border border-border-primary rounded-lg px-4 py-3 shadow-lg">
-          <span className="text-sm text-text-primary">
-            {t("overlay.connectionLost")}
-          </span>
-          <button
-            onClick={() => {
-              setPeerDisconnected(false);
-              setPeerModalOpen(true);
-            }}
-            className="bg-blue-600 hover:bg-blue-700 text-white px-3 py-1 rounded text-sm transition font-semibold"
-          >
-            {t("overlay.reconnect")}
-          </button>
-          <button
-            onClick={() => setPeerDisconnected(false)}
-            className="text-text-muted hover:text-text-primary transition text-sm"
-          >
-            {t("overlay.dismiss")}
-          </button>
+          {isReconnecting ? (
+            <>
+              <Loader2 className="w-4 h-4 animate-spin text-text-muted" />
+              <span className="text-sm text-text-primary">
+                {t("overlay.reconnecting")}
+              </span>
+            </>
+          ) : (
+            <>
+              <span className="text-sm text-text-primary">
+                {t("overlay.connectionLost")}
+              </span>
+              <button
+                onClick={() => {
+                  if (lastRoomCode) {
+                    reconnectToRoom(lastRoomCode);
+                  } else {
+                    setPeerDisconnected(false);
+                    setPeerModalOpen(true);
+                  }
+                }}
+                className="bg-blue-600 hover:bg-blue-700 text-white px-3 py-1 rounded text-sm transition font-semibold"
+              >
+                {t("overlay.reconnect")}
+              </button>
+              <button
+                onClick={() => setPeerDisconnected(false)}
+                className="text-text-muted hover:text-text-primary transition text-sm"
+              >
+                {t("overlay.dismiss")}
+              </button>
+            </>
+          )}
         </div>
       )}
 
@@ -281,6 +399,40 @@ export default function MapViewer() {
           <p className="text-white/30 text-xs">
             {t("overlay.waitingForDmHint")}
           </p>
+        </div>
+      )}
+
+      {/* Debug toggle button */}
+      <button
+        onClick={() => setShowDebug((v) => !v)}
+        className="absolute bottom-16 right-2 z-50 bg-black/60 text-green-400 text-xs font-mono px-2 py-1 rounded border border-green-400/40"
+      >
+        DBG
+      </button>
+
+      {/* Debug panel */}
+      {showDebug && (
+        <div className="absolute bottom-24 right-2 z-50 bg-black/90 text-green-400 text-xs font-mono p-2 rounded border border-green-400/30 w-72 max-h-64 overflow-y-auto">
+          <div className="mb-1 text-green-300 font-bold">Connection state</div>
+          <div>view: {view}</div>
+          <div>transport: {peerTransport ? "connected" : "none"}</div>
+          <div>
+            isConnected:{" "}
+            {peerTransport ? String(peerTransport.isConnected()) : "n/a"}
+          </div>
+          <div>peerDisconnected: {String(peerDisconnected)}</div>
+          <div>isReconnecting: {String(isReconnecting)}</div>
+          <div>lastRoomCode: {lastRoomCode ?? "none"}</div>
+          <div className="mt-2 text-green-300 font-bold">Visibility log</div>
+          {debugLog.length === 0 ? (
+            <div className="text-green-600">no events yet</div>
+          ) : (
+            debugLog.map((entry, i) => (
+              <div key={i} className="break-all">
+                {entry}
+              </div>
+            ))
+          )}
         </div>
       )}
 

--- a/src/components/MapViewer/PeerJSConnector.tsx
+++ b/src/components/MapViewer/PeerJSConnector.tsx
@@ -13,7 +13,11 @@ type Step =
   | { kind: "error"; message: string };
 
 interface Props {
-  onConnected: (transport: MapTransport, role: "dm" | "player") => void;
+  onConnected: (
+    transport: MapTransport,
+    role: "dm" | "player",
+    roomCode?: string,
+  ) => void;
   onClose: () => void;
 }
 
@@ -63,6 +67,13 @@ export default function PeerJSConnector({ onConnected, onClose }: Props) {
     const peer = new Peer();
     peerRef.current = peer;
 
+    peer.on("disconnected", () => {
+      console.log(`DEBUG ==> [DM] peer "disconnected" event (signaling server lost)`);
+    });
+    peer.on("close", () => {
+      console.log(`DEBUG ==> [DM] peer "close" event (peer destroyed)`);
+    });
+
     peer.on("open", (id) => {
       // Also fires after peer.reconnect(). Skip update only if ID is unchanged —
       // if the server assigned a new ID, update the displayed room code.
@@ -101,18 +112,28 @@ export default function PeerJSConnector({ onConnected, onClose }: Props) {
     const peer = new Peer();
     peerRef.current = peer;
 
-    peer.on("open", () => {
+    peer.on("open", (id) => {
+      console.log(`DEBUG ==> [Player] peer "open", peerId=${id}, connecting to room=${roomCode.trim()}`);
       const conn = peer.connect(roomCode.trim());
       conn.on("open", () => {
+        console.log(`DEBUG ==> [Player] conn "open" — connected to DM`);
         connectedRef.current = true;
-        onConnected(new PeerJSTransport(conn), "player");
+        onConnected(new PeerJSTransport(conn), "player", roomCode.trim());
       });
       conn.on("error", (err) => {
+        console.log(`DEBUG ==> [Player] conn "error":`, err);
         setStep({ kind: "error", message: err.message });
       });
     });
 
+    peer.on("disconnected", () => {
+      console.log(`DEBUG ==> [Player] peer "disconnected" event (signaling server lost)`);
+    });
+    peer.on("close", () => {
+      console.log(`DEBUG ==> [Player] peer "close" event (peer destroyed)`);
+    });
     peer.on("error", (err) => {
+      console.log(`DEBUG ==> [Player] peer "error":`, err);
       setStep({ kind: "error", message: err.message });
     });
   };

--- a/src/components/MapViewer/PeerJSConnector.tsx
+++ b/src/components/MapViewer/PeerJSConnector.tsx
@@ -67,13 +67,6 @@ export default function PeerJSConnector({ onConnected, onClose }: Props) {
     const peer = new Peer();
     peerRef.current = peer;
 
-    peer.on("disconnected", () => {
-      console.log(`DEBUG ==> [DM] peer "disconnected" event (signaling server lost)`);
-    });
-    peer.on("close", () => {
-      console.log(`DEBUG ==> [DM] peer "close" event (peer destroyed)`);
-    });
-
     peer.on("open", (id) => {
       // Also fires after peer.reconnect(). Skip update only if ID is unchanged —
       // if the server assigned a new ID, update the displayed room code.
@@ -112,28 +105,18 @@ export default function PeerJSConnector({ onConnected, onClose }: Props) {
     const peer = new Peer();
     peerRef.current = peer;
 
-    peer.on("open", (id) => {
-      console.log(`DEBUG ==> [Player] peer "open", peerId=${id}, connecting to room=${roomCode.trim()}`);
+    peer.on("open", () => {
       const conn = peer.connect(roomCode.trim());
       conn.on("open", () => {
-        console.log(`DEBUG ==> [Player] conn "open" — connected to DM`);
         connectedRef.current = true;
         onConnected(new PeerJSTransport(conn), "player", roomCode.trim());
       });
       conn.on("error", (err) => {
-        console.log(`DEBUG ==> [Player] conn "error":`, err);
         setStep({ kind: "error", message: err.message });
       });
     });
 
-    peer.on("disconnected", () => {
-      console.log(`DEBUG ==> [Player] peer "disconnected" event (signaling server lost)`);
-    });
-    peer.on("close", () => {
-      console.log(`DEBUG ==> [Player] peer "close" event (peer destroyed)`);
-    });
     peer.on("error", (err) => {
-      console.log(`DEBUG ==> [Player] peer "error":`, err);
       setStep({ kind: "error", message: err.message });
     });
   };

--- a/src/components/MapViewer/PeerJSConnector.tsx
+++ b/src/components/MapViewer/PeerJSConnector.tsx
@@ -1,4 +1,4 @@
-import { Copy, Loader2, Radio, Wifi, X } from "lucide-react";
+import { Copy, Loader2, Monitor, Radio, Wifi, X } from "lucide-react";
 import { useEffect, useRef, useState } from "react";
 import Peer from "peerjs";
 import { useTranslation } from "react-i18next";
@@ -18,10 +18,15 @@ interface Props {
     role: "dm" | "player",
     roomCode?: string,
   ) => void;
+  onOpenLocalView: () => void;
   onClose: () => void;
 }
 
-export default function PeerJSConnector({ onConnected, onClose }: Props) {
+export default function PeerJSConnector({
+  onConnected,
+  onOpenLocalView,
+  onClose,
+}: Props) {
   const { t } = useTranslation("map");
   const [step, setStep] = useState<Step>({ kind: "choosing" });
   const [copied, setCopied] = useState(false);
@@ -128,6 +133,12 @@ export default function PeerJSConnector({ onConnected, onClose }: Props) {
     });
   };
 
+  const networkWarning = (
+    <p className="text-xs text-amber-400 bg-amber-400/10 border border-amber-400/20 rounded-lg px-3 py-2 w-full text-center">
+      {t("connector.sameNetworkWarning")}
+    </p>
+  );
+
   return (
     <div className="absolute inset-0 z-30 bg-black/50 backdrop-blur-sm flex items-center justify-center p-4">
       <div className="bg-panel-bg border border-border-primary rounded-xl p-6 w-full max-w-sm flex flex-col gap-5 relative">
@@ -141,10 +152,6 @@ export default function PeerJSConnector({ onConnected, onClose }: Props) {
         <h2 className="text-lg font-bold text-text-primary">
           {t("connector.title")}
         </h2>
-
-        <p className="text-xs text-amber-400 bg-amber-400/10 border border-amber-400/20 rounded-lg px-3 py-2">
-          {t("connector.sameNetworkWarning")}
-        </p>
 
         {step.kind === "choosing" && (
           <div className="flex flex-col gap-3">
@@ -172,11 +179,27 @@ export default function PeerJSConnector({ onConnected, onClose }: Props) {
                 </p>
               </span>
             </button>
+            <button
+              onClick={() => {
+                onOpenLocalView();
+                onClose();
+              }}
+              className="bg-panel-secondary hover:bg-panel-secondary/70 text-text-primary px-4 py-4 rounded-lg transition font-semibold flex items-center gap-3"
+            >
+              <Monitor className="w-5 h-5 shrink-0" />
+              <span className="text-left">
+                <p>{t("connector.openLocalView")}</p>
+                <p className="text-xs text-text-muted font-normal">
+                  {t("connector.openLocalViewHint")}
+                </p>
+              </span>
+            </button>
           </div>
         )}
 
         {step.kind === "dm-waiting" && (
           <div className="flex flex-col items-center gap-4">
+            {networkWarning}
             <Loader2 className="w-7 h-7 text-text-muted animate-spin" />
             <p className="text-text-muted text-sm">
               {t("connector.waitingForPlayer")}
@@ -214,6 +237,7 @@ export default function PeerJSConnector({ onConnected, onClose }: Props) {
 
         {(step.kind === "player-ready" || step.kind === "connecting") && (
           <div className="flex flex-col gap-3">
+            {networkWarning}
             <input
               type="text"
               value={step.input}

--- a/src/components/MapViewer/PeerJSTransport.ts
+++ b/src/components/MapViewer/PeerJSTransport.ts
@@ -9,33 +9,21 @@ export class PeerJSTransport implements MapTransport {
 
   constructor(conn: DataConnection) {
     this.conn = conn;
-    console.log(`DEBUG ==> PeerJSTransport created, conn.open=${conn.open}`);
 
     conn.on("data", (data) => {
-      console.log(
-        `DEBUG ==> PeerJSTransport received message:`,
-        (data as MapMessage).type,
-      );
       this.handlers.forEach((h) => h(data as MapMessage));
     });
 
     conn.on("close", () => {
-      console.log(
-        `DEBUG ==> PeerJSTransport conn "close" event fired, conn.open=${conn.open}`,
-      );
       this.triggerClose();
     });
 
-    conn.on("error", (err) => {
-      console.log(`DEBUG ==> PeerJSTransport conn "error" event:`, err);
-    });
+    conn.on("error", () => {});
 
     // On iOS, WebRTC connections die silently when backgrounded — "close" never
     // fires. ICE "failed" is the reliable signal that the connection is dead.
     conn.on("iceStateChanged", (state) => {
-      console.log(`DEBUG ==> PeerJSTransport ICE state changed:`, state);
       if (state === "failed") {
-        console.log(`DEBUG ==> PeerJSTransport ICE failed → triggering close`);
         this.triggerClose();
       }
     });
@@ -48,7 +36,6 @@ export class PeerJSTransport implements MapTransport {
   }
 
   send(msg: MapMessage) {
-    console.log(`DEBUG ==> PeerJSTransport sending message:`, msg.type);
     this.conn.send(msg);
   }
 
@@ -58,7 +45,6 @@ export class PeerJSTransport implements MapTransport {
   }
 
   onClose(handler: () => void): () => void {
-    console.log(`DEBUG ==> PeerJSTransport onClose handler registered`);
     this.closeHandlers.add(handler);
     return () => this.closeHandlers.delete(handler);
   }
@@ -66,14 +52,10 @@ export class PeerJSTransport implements MapTransport {
   isConnected(): boolean {
     if (!this.conn.open) return false;
     const ice = this.conn.peerConnection?.iceConnectionState;
-    console.log(
-      `DEBUG ==> isConnected check: conn.open=${this.conn.open} iceState=${ice}`,
-    );
     return ice !== "failed" && ice !== "disconnected" && ice !== "closed";
   }
 
   close() {
-    console.log(`DEBUG ==> PeerJSTransport.close() called`);
     this.conn.close();
     // Intentionally not calling peer.destroy() here:
     // React Strict Mode runs effect cleanup prematurely which would kill the

--- a/src/components/MapViewer/PeerJSTransport.ts
+++ b/src/components/MapViewer/PeerJSTransport.ts
@@ -3,16 +3,52 @@ import type { MapMessage, MapTransport } from "./types";
 
 export class PeerJSTransport implements MapTransport {
   private handlers = new Set<(msg: MapMessage) => void>();
+  private closeHandlers = new Set<() => void>();
   private conn: DataConnection;
+  private closeFired = false;
 
   constructor(conn: DataConnection) {
     this.conn = conn;
+    console.log(`DEBUG ==> PeerJSTransport created, conn.open=${conn.open}`);
+
     conn.on("data", (data) => {
+      console.log(
+        `DEBUG ==> PeerJSTransport received message:`,
+        (data as MapMessage).type,
+      );
       this.handlers.forEach((h) => h(data as MapMessage));
+    });
+
+    conn.on("close", () => {
+      console.log(
+        `DEBUG ==> PeerJSTransport conn "close" event fired, conn.open=${conn.open}`,
+      );
+      this.triggerClose();
+    });
+
+    conn.on("error", (err) => {
+      console.log(`DEBUG ==> PeerJSTransport conn "error" event:`, err);
+    });
+
+    // On iOS, WebRTC connections die silently when backgrounded — "close" never
+    // fires. ICE "failed" is the reliable signal that the connection is dead.
+    conn.on("iceStateChanged", (state) => {
+      console.log(`DEBUG ==> PeerJSTransport ICE state changed:`, state);
+      if (state === "failed") {
+        console.log(`DEBUG ==> PeerJSTransport ICE failed → triggering close`);
+        this.triggerClose();
+      }
     });
   }
 
+  private triggerClose() {
+    if (this.closeFired) return;
+    this.closeFired = true;
+    this.closeHandlers.forEach((h) => h());
+  }
+
   send(msg: MapMessage) {
+    console.log(`DEBUG ==> PeerJSTransport sending message:`, msg.type);
     this.conn.send(msg);
   }
 
@@ -22,11 +58,22 @@ export class PeerJSTransport implements MapTransport {
   }
 
   onClose(handler: () => void): () => void {
-    this.conn.on("close", handler);
-    return () => this.conn.off("close", handler);
+    console.log(`DEBUG ==> PeerJSTransport onClose handler registered`);
+    this.closeHandlers.add(handler);
+    return () => this.closeHandlers.delete(handler);
+  }
+
+  isConnected(): boolean {
+    if (!this.conn.open) return false;
+    const ice = this.conn.peerConnection?.iceConnectionState;
+    console.log(
+      `DEBUG ==> isConnected check: conn.open=${this.conn.open} iceState=${ice}`,
+    );
+    return ice !== "failed" && ice !== "disconnected" && ice !== "closed";
   }
 
   close() {
+    console.log(`DEBUG ==> PeerJSTransport.close() called`);
     this.conn.close();
     // Intentionally not calling peer.destroy() here:
     // React Strict Mode runs effect cleanup prematurely which would kill the

--- a/src/components/MapViewer/components/MapToolbar.tsx
+++ b/src/components/MapViewer/components/MapToolbar.tsx
@@ -104,6 +104,7 @@ export default function MapToolbar({
             <LocateFixed className="w-4 h-4" />
           </button>
         )}
+        <span className="w-px h-4 bg-border-primary mx-1" />
         {view === "dm" && (
           <button
             onClick={onToggleFocusMode}

--- a/src/components/MapViewer/components/MapToolbar.tsx
+++ b/src/components/MapViewer/components/MapToolbar.tsx
@@ -31,8 +31,9 @@ interface Props {
   onImport: (e: React.ChangeEvent<HTMLInputElement>) => void;
   tokenCount: number;
   onOpenTokenModal: () => void;
-  onOpenPlayerView: () => void;
   onOpenPeerModal: () => void;
+  isPeerConnected: boolean;
+  isReconnecting: boolean;
 }
 
 export default function MapToolbar({
@@ -55,8 +56,9 @@ export default function MapToolbar({
   onImport,
   tokenCount,
   onOpenTokenModal,
-  onOpenPlayerView,
   onOpenPeerModal,
+  isPeerConnected,
+  isReconnecting,
 }: Props) {
   const { t } = useTranslation("map");
 
@@ -80,6 +82,16 @@ export default function MapToolbar({
         >
           {view === "dm" ? t("toolbar.dmView") : t("toolbar.playerView")}
         </span>
+        {view === "player" && (isReconnecting || isPeerConnected) && (
+          <span
+            className={`w-2 h-2 rounded-full ${isReconnecting ? "bg-orange-400 animate-pulse" : "bg-green-400"}`}
+            title={
+              isReconnecting
+                ? t("overlay.reconnecting")
+                : t("toolbar.connectedToDm")
+            }
+          />
+        )}
         <span className="text-text-muted text-xs tabular-nums ml-1">
           {Math.round(cameraScale * 100)}%
         </span>
@@ -196,29 +208,26 @@ export default function MapToolbar({
             </button>
           </div>
 
-          {/* Section 4 — sync */}
+          {/* Section 4 — connect */}
           <div className="flex items-center gap-1 bg-panel-bg/90 border border-border-primary rounded-lg px-2 py-1">
-            <span className="text-xs text-text-muted px-1 select-none">
-              {t("toolbar.local")}
-            </span>
-            <button
-              onClick={onOpenPlayerView}
-              className="hover:bg-panel-secondary text-text-primary px-2 py-1 rounded text-sm transition"
-            >
-              {t("toolbar.openPlayerView")}
-            </button>
-            <span className="w-px h-4 bg-border-primary mx-1" />
-            <span className="text-xs text-text-muted px-1 select-none">
-              {t("toolbar.online")}
-            </span>
             <button
               onClick={onOpenPeerModal}
               className="hover:bg-panel-secondary text-text-primary px-2 py-1 rounded text-sm transition flex items-center gap-1.5"
-              title={t("toolbar.connectOnlineTitle")}
+              title={t("toolbar.connectTitle")}
             >
               <Wifi className="w-4 h-4" />
-              {t("toolbar.connectOnline")}
+              {t("toolbar.connect")}
             </button>
+            {(isPeerConnected || isReconnecting) && (
+              <span className="flex items-center gap-1.5 px-2 py-1 text-xs text-text-muted">
+                {isReconnecting ? (
+                  <span className="w-2 h-2 rounded-full bg-orange-400 animate-pulse" />
+                ) : (
+                  <span className="w-2 h-2 rounded-full bg-green-400" />
+                )}
+                {!isReconnecting && t("toolbar.playerConnected")}
+              </span>
+            )}
           </div>
         </>
       )}

--- a/src/components/MapViewer/hooks/useMapInteraction.ts
+++ b/src/components/MapViewer/hooks/useMapInteraction.ts
@@ -628,6 +628,20 @@ export function useMapInteraction({
     location.hash = "";
   }, [mapStateRef]);
 
+  const recenterOnPlayer = useCallback(() => {
+    const tokens = mapStateRef.current!.tokens;
+    const token =
+      tokens.find((t) => t.id === "player") ?? tokens.find((t) => !t.hidden);
+    if (!token) return;
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    setCamera((prev) => ({
+      ...prev,
+      x: canvas.width / 2 - token.x * prev.scale,
+      y: canvas.height / 2 - token.y * prev.scale,
+    }));
+  }, [mapStateRef, canvasRef, setCamera]);
+
   return {
     draggingTokenIdRef,
     draggingTokenPosRef,
@@ -648,5 +662,6 @@ export function useMapInteraction({
     handleImport,
     openPlayerView,
     handleBack,
+    recenterOnPlayer,
   };
 }

--- a/src/components/MapViewer/hooks/useMapSync.ts
+++ b/src/components/MapViewer/hooks/useMapSync.ts
@@ -31,14 +31,17 @@ export function useMapSync({
 
   useEffect(() => {
     const isLocalTransport = !peerTransport;
+    console.log(`DEBUG ==> useMapSync effect, view=${view}, hasPeerTransport=${!!peerTransport}`);
     const transport = peerTransport ?? new BroadcastChannelTransport();
     transportRef.current = transport;
 
     const unsub = transport.onMessage((msg: MapMessage) => {
+      console.log(`DEBUG ==> useMapSync received msg: ${msg.type}, view=${view}`);
       if (view === "player") setSynced(true);
       switch (msg.type) {
         case "REQUEST_FULL_STATE":
           if (view === "dm") {
+            console.log(`DEBUG ==> [DM] responding to REQUEST_FULL_STATE`);
             transport.send({
               type: "FULL_STATE_RESPONSE",
               state: mapStateRef.current!,
@@ -75,10 +78,12 @@ export function useMapSync({
     });
 
     if (view === "player") {
+      console.log(`DEBUG ==> [Player] sending REQUEST_FULL_STATE`);
       transport.send({ type: "REQUEST_FULL_STATE" });
     }
 
     const unsubClose = transport.onClose(() => {
+      console.log(`DEBUG ==> useMapSync onClose fired, view=${view}`);
       setPeerTransport(null);
       setPeerDisconnected(true);
     });

--- a/src/components/MapViewer/hooks/useMapSync.ts
+++ b/src/components/MapViewer/hooks/useMapSync.ts
@@ -1,5 +1,9 @@
-import { useEffect, useState } from "react";
+import Peer from "peerjs";
+import { useCallback, useEffect, useState } from "react";
+import { useTranslation } from "react-i18next";
+import { useToast } from "../../common/Toast/useToast";
 import { BroadcastChannelTransport } from "../BroadcastChannelTransport";
+import { PeerJSTransport } from "../PeerJSTransport";
 import type { MapMessage, MapState, MapTransport, PingEntry } from "../types";
 
 interface Params {
@@ -12,6 +16,7 @@ interface Params {
   setMapState: React.Dispatch<React.SetStateAction<MapState>>;
   setPeerTransport: React.Dispatch<React.SetStateAction<MapTransport | null>>;
   setPeerDisconnected: React.Dispatch<React.SetStateAction<boolean>>;
+  setIsReconnecting: React.Dispatch<React.SetStateAction<boolean>>;
   onCenterCamera: (x: number, y: number) => void;
 }
 
@@ -25,23 +30,49 @@ export function useMapSync({
   setMapState,
   setPeerTransport,
   setPeerDisconnected,
+  setIsReconnecting,
   onCenterCamera,
-}: Params): { synced: boolean } {
+}: Params): { synced: boolean; reconnectToRoom: (roomCode: string) => void } {
   const [synced, setSynced] = useState(view === "dm");
+  const toast = useToast();
+  const { t } = useTranslation("map");
+
+  const reconnectToRoom = useCallback(
+    (roomCode: string) => {
+      setIsReconnecting(true);
+      const peer = new Peer();
+      peer.on("open", () => {
+        const conn = peer.connect(roomCode);
+        conn.on("open", () => {
+          setPeerTransport(new PeerJSTransport(conn));
+          setPeerDisconnected(false);
+          setIsReconnecting(false);
+        });
+        conn.on("error", (err) => {
+          peer.destroy();
+          setIsReconnecting(false);
+          toast.error(`${t("overlay.reconnectFailed")}: ${err.type}`);
+        });
+      });
+      peer.on("error", (err) => {
+        peer.destroy();
+        setIsReconnecting(false);
+        toast.error(`${t("overlay.reconnectFailed")}: ${err.type}`);
+      });
+    },
+    [toast, t, setIsReconnecting, setPeerTransport, setPeerDisconnected],
+  );
 
   useEffect(() => {
     const isLocalTransport = !peerTransport;
-    console.log(`DEBUG ==> useMapSync effect, view=${view}, hasPeerTransport=${!!peerTransport}`);
     const transport = peerTransport ?? new BroadcastChannelTransport();
     transportRef.current = transport;
 
     const unsub = transport.onMessage((msg: MapMessage) => {
-      console.log(`DEBUG ==> useMapSync received msg: ${msg.type}, view=${view}`);
       if (view === "player") setSynced(true);
       switch (msg.type) {
         case "REQUEST_FULL_STATE":
           if (view === "dm") {
-            console.log(`DEBUG ==> [DM] responding to REQUEST_FULL_STATE`);
             transport.send({
               type: "FULL_STATE_RESPONSE",
               state: mapStateRef.current!,
@@ -78,12 +109,10 @@ export function useMapSync({
     });
 
     if (view === "player") {
-      console.log(`DEBUG ==> [Player] sending REQUEST_FULL_STATE`);
       transport.send({ type: "REQUEST_FULL_STATE" });
     }
 
     const unsubClose = transport.onClose(() => {
-      console.log(`DEBUG ==> useMapSync onClose fired, view=${view}`);
       setPeerTransport(null);
       setPeerDisconnected(true);
     });
@@ -108,5 +137,5 @@ export function useMapSync({
     onCenterCamera,
   ]);
 
-  return { synced };
+  return { synced, reconnectToRoom };
 }

--- a/src/components/MapViewer/types.ts
+++ b/src/components/MapViewer/types.ts
@@ -55,5 +55,6 @@ export interface MapTransport {
   send(msg: MapMessage): void;
   onMessage(handler: (msg: MapMessage) => void): () => void; // returns unsubscribe fn
   onClose(handler: () => void): () => void; // returns unsubscribe fn
+  isConnected(): boolean;
   close(): void;
 }

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -89,6 +89,7 @@ export const SETTINGS_STORAGE_KEY = "dnd-ct:settings:v1";
 export const BUILDING_BLOCK_STORAGE_KEY = "dnd-ct:blocks:v1";
 export const CAMPAIGN_STORAGE_KEY = "dnd-ct:campaigns:v1";
 export const BLOCK_TYPE_STORAGE_KEY = "dnd-ct:block-types:v1";
+export const MAP_ROOM_CODE_STORAGE_KEY = "dnd-ct:map-room-code";
 
 export const BUILT_IN_BLOCK_TYPES: BlockTypeDef[] = [
   {

--- a/src/i18n/locales/en/map.json
+++ b/src/i18n/locales/en/map.json
@@ -14,11 +14,10 @@
     "resetFogTitle": "Reset all fog",
     "tokens": "Tokens",
     "manageTokens": "Manage tokens",
-    "local": "Local",
-    "openPlayerView": "Open Player View",
-    "online": "Online",
-    "connectOnline": "Connect Online",
-    "connectOnlineTitle": "Connect online via PeerJS"
+    "connect": "Connect",
+    "connectTitle": "Connect players",
+    "playerConnected": "Player connected",
+    "connectedToDm": "Connected to DM"
   },
   "overlay": {
     "waitingForDm": "Waiting for DM…",
@@ -40,6 +39,8 @@
     "startAsDmHint": "Host the session — share a room code",
     "joinAsPlayer": "Join as Player",
     "joinAsPlayerHint": "Enter the room code from the DM",
+    "openLocalView": "Open Local Player View",
+    "openLocalViewHint": "Same device — no network needed",
     "waitingForPlayer": "Waiting for player to connect…",
     "roomCode": "Room code",
     "copyRoomCode": "Copy room code",

--- a/src/i18n/locales/en/map.json
+++ b/src/i18n/locales/en/map.json
@@ -26,6 +26,7 @@
     "importMapHint": "Import a map to get started",
     "connectionLost": "Connection lost",
     "reconnect": "Reconnect",
+    "reconnecting": "Reconnecting…",
     "dismiss": "Dismiss"
   },
   "confirm": {

--- a/src/i18n/locales/en/map.json
+++ b/src/i18n/locales/en/map.json
@@ -27,6 +27,7 @@
     "connectionLost": "Connection lost",
     "reconnect": "Reconnect",
     "reconnecting": "Reconnecting…",
+    "reconnectFailed": "Reconnect failed",
     "dismiss": "Dismiss"
   },
   "confirm": {

--- a/src/i18n/locales/fr/map.json
+++ b/src/i18n/locales/fr/map.json
@@ -26,6 +26,7 @@
     "importMapHint": "Importez une carte pour commencer",
     "connectionLost": "Connexion perdue",
     "reconnect": "Reconnecter",
+    "reconnecting": "Reconnexion…",
     "dismiss": "Ignorer"
   },
   "confirm": {

--- a/src/i18n/locales/fr/map.json
+++ b/src/i18n/locales/fr/map.json
@@ -27,6 +27,7 @@
     "connectionLost": "Connexion perdue",
     "reconnect": "Reconnecter",
     "reconnecting": "Reconnexion…",
+    "reconnectFailed": "Reconnexion échouée",
     "dismiss": "Ignorer"
   },
   "confirm": {

--- a/src/i18n/locales/fr/map.json
+++ b/src/i18n/locales/fr/map.json
@@ -14,11 +14,10 @@
     "resetFogTitle": "Réinitialiser tout le brouillard",
     "tokens": "Pions",
     "manageTokens": "Gérer les pions",
-    "local": "Local",
-    "openPlayerView": "Ouvrir la vue joueur",
-    "online": "En ligne",
-    "connectOnline": "Connexion en ligne",
-    "connectOnlineTitle": "Se connecter en ligne via PeerJS"
+    "connect": "Connecter",
+    "connectTitle": "Connecter les joueurs",
+    "playerConnected": "Joueur connecté",
+    "connectedToDm": "Connecté au MJ"
   },
   "overlay": {
     "waitingForDm": "En attente du MJ…",
@@ -40,6 +39,8 @@
     "startAsDmHint": "Héberger la session — partager un code de salle",
     "joinAsPlayer": "Rejoindre en tant que Joueur",
     "joinAsPlayerHint": "Entrez le code de salle du MJ",
+    "openLocalView": "Ouvrir la vue joueur locale",
+    "openLocalViewHint": "Même appareil — pas de réseau requis",
     "waitingForPlayer": "En attente d'un joueur…",
     "roomCode": "Code de salle",
     "copyRoomCode": "Copier le code de salle",


### PR DESCRIPTION
This pull request adds automatic reconnection support to the `MapViewer` component for PeerJS-based multiplayer sessions. When a user's connection is lost, the app now attempts to automatically reconnect when the browser tab becomes visible again, and provides improved user feedback during the reconnection process.

Connection and reconnection improvements:

* Added state management in `MapViewer.tsx` to track the last room code, reconnection status (`isReconnecting`), and to handle reconnection logic using a new `reconnectToRoom` callback. When the tab regains focus and the connection is lost, the app tries to reconnect automatically. [[1]](diffhunk://#diff-196cae4265e24183d95df0f1d1730b57220be6e4ef02e6896a307e7f6d2b927fR54-R55) [[2]](diffhunk://#diff-196cae4265e24183d95df0f1d1730b57220be6e4ef02e6896a307e7f6d2b927fR185-R211) [[3]](diffhunk://#diff-196cae4265e24183d95df0f1d1730b57220be6e4ef02e6896a307e7f6d2b927fL228-R267)
* Updated the disconnected banner UI in `MapViewer.tsx` to display a loading spinner and a "Reconnecting…" message during reconnection attempts, and to allow manual reconnection if automatic reconnection fails. [[1]](diffhunk://#diff-196cae4265e24183d95df0f1d1730b57220be6e4ef02e6896a307e7f6d2b927fL252-R308) [[2]](diffhunk://#diff-196cae4265e24183d95df0f1d1730b57220be6e4ef02e6896a307e7f6d2b927fR320-R321)
* Modified the `PeerJSConnector` component to pass the `roomCode` back to `MapViewer` upon successful connection, enabling reconnection attempts to the correct room. [[1]](diffhunk://#diff-c944e08c3a91cf99d51145e4c24d889293608614df98f1b198ed311d5384b7e4L16-R20) [[2]](diffhunk://#diff-c944e08c3a91cf99d51145e4c24d889293608614df98f1b198ed311d5384b7e4L108-R112)

Localization:

* Added new translation keys for "Reconnecting…" in both English and French locale files. [[1]](diffhunk://#diff-c448f16f60235f6e5c78f7a5d8391a1d4682a08f2615f1042621ed1f0b497728R29) [[2]](diffhunk://#diff-5f8c08e534aa23cb6858e44df085f4c7e58047c08a8369100e18b04831715589R29)

Dependency and import updates:

* Imported the `Loader2` spinner icon and `PeerJSTransport` in `MapViewer.tsx` to support the new UI and reconnection logic. [[1]](diffhunk://#diff-196cae4265e24183d95df0f1d1730b57220be6e4ef02e6896a307e7f6d2b927fL1-R1) [[2]](diffhunk://#diff-196cae4265e24183d95df0f1d1730b57220be6e4ef02e6896a307e7f6d2b927fR11-R15)