### PR TITLE
Display visibility radius 

### DIFF
--- a/src/components/MapViewer/MapViewer.tsx
+++ b/src/components/MapViewer/MapViewer.tsx
@@ -61,6 +61,8 @@ export default function MapViewer() {
   const [undoStack, setUndoStack] = useState<HistoryEntry[]>([]);
   const [redoStack, setRedoStack] = useState<HistoryEntry[]>([]);
   const [revealRadius, setRevealRadius] = useState(145);
+  const isRadiusPreviewActiveRef = useRef(false);
+  const previewTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const [tokenModalOpen, setTokenModalOpen] = useState(false);
   const [selectedTokenId, setSelectedTokenId] = useState<string | null>(null);
   const [portraitViewTokenId, setPortraitViewTokenId] = useState<string | null>(
@@ -179,6 +181,7 @@ export default function MapViewer() {
     draggingTokenIdRef,
     draggingTokenPosRef,
     revealRadiusRef,
+    isRadiusPreviewActiveRef,
     pingsRef,
   });
 
@@ -285,7 +288,15 @@ export default function MapViewer() {
         onRecenterOnPlayer={recenterOnPlayer}
         onBack={handleBack}
         revealRadius={revealRadius}
-        onRevealRadiusChange={setRevealRadius}
+        onRevealRadiusChange={(r: number) => {
+          setRevealRadius(r);
+          isRadiusPreviewActiveRef.current = true;
+          if (previewTimeoutRef.current)
+            clearTimeout(previewTimeoutRef.current);
+          previewTimeoutRef.current = setTimeout(() => {
+            isRadiusPreviewActiveRef.current = false;
+          }, 1500);
+        }}
         canUndo={undoStack.length > 0}
         canRedo={redoStack.length > 0}
         onUndo={undo}

--- a/src/components/MapViewer/hooks/useMapRenderer.ts
+++ b/src/components/MapViewer/hooks/useMapRenderer.ts
@@ -18,6 +18,7 @@ interface Params {
   draggingTokenIdRef: React.RefObject<string | null>;
   draggingTokenPosRef: React.RefObject<{ x: number; y: number } | null>;
   revealRadiusRef: React.RefObject<number>;
+  isRadiusPreviewActiveRef: React.RefObject<boolean>;
   pingsRef: React.RefObject<PingEntry[]>;
 }
 
@@ -190,6 +191,28 @@ function drawTokens(
   }
 }
 
+function drawRadiusPreview(
+  ctx: CanvasRenderingContext2D,
+  scale: number,
+  panX: number,
+  panY: number,
+  tokens: Token[],
+  revealRadiusRef: React.RefObject<number>,
+) {
+  const radius = revealRadiusRef.current!;
+  ctx.setTransform(scale, 0, 0, scale, panX, panY);
+  ctx.setLineDash([6 / scale, 4 / scale]);
+  ctx.strokeStyle = "rgba(96, 165, 250, 0.85)";
+  ctx.lineWidth = 2 / scale;
+  for (const token of tokens) {
+    if (!token.revealsFog) continue;
+    ctx.beginPath();
+    ctx.arc(token.x, token.y, radius, 0, Math.PI * 2);
+    ctx.stroke();
+  }
+  ctx.setLineDash([]);
+}
+
 function drawPings(
   ctx: CanvasRenderingContext2D,
   scale: number,
@@ -239,6 +262,7 @@ export function useMapRenderer({
   draggingTokenIdRef,
   draggingTokenPosRef,
   revealRadiusRef,
+  isRadiusPreviewActiveRef,
   pingsRef,
 }: Params): void {
   const fogCanvasRef = useRef<OffscreenCanvas | null>(null);
@@ -346,10 +370,15 @@ export function useMapRenderer({
         draggingTokenPosRef,
       );
 
-      // 5. Pointer pings
+      // 5. Radius preview (while adjusting the slider)
+      if (isRadiusPreviewActiveRef.current && view === "dm") {
+        drawRadiusPreview(ctx, scale, panX, panY, stateTokens, revealRadiusRef);
+      }
+
+      // 6. Pointer pings
       drawPings(ctx, scale, panX, panY, pingsRef);
 
-      // 6. Reset transform
+      // 7. Reset transform
       ctx.setTransform(1, 0, 0, 1, 0, 0);
 
       rafId = requestAnimationFrame(render);
@@ -365,6 +394,7 @@ export function useMapRenderer({
     draggingTokenIdRef,
     draggingTokenPosRef,
     revealRadiusRef,
+    isRadiusPreviewActiveRef,
     pingsRef,
   ]);
 }


### PR DESCRIPTION
This pull request adds a visual "radius preview" feature to the map viewer, allowing users to see a temporary outline of the reveal radius when adjusting it. The implementation uses React refs and a timeout to control when the preview is displayed, and updates the map rendering logic to show the preview only while the user is actively adjusting the radius.

**Radius Preview Feature:**

* Added `isRadiusPreviewActiveRef` and `previewTimeoutRef` to `MapViewer.tsx` to track when the radius preview should be shown and to manage the timeout for hiding it after adjustments.
* Updated the `onRevealRadiusChange` handler to activate the preview and set a 1.5 second timeout to hide it after the user stops adjusting the radius.
* Passed `isRadiusPreviewActiveRef` through the map rendering hooks and parameters to make it available for rendering logic. [[1]](diffhunk://#diff-196cae4265e24183d95df0f1d1730b57220be6e4ef02e6896a307e7f6d2b927fR184) [[2]](diffhunk://#diff-788c442cfffe4761174c14c56a93f91854dd2c857877f466d284f5dfcaad0022R21) [[3]](diffhunk://#diff-788c442cfffe4761174c14c56a93f91854dd2c857877f466d284f5dfcaad0022R265) [[4]](diffhunk://#diff-788c442cfffe4761174c14c56a93f91854dd2c857877f466d284f5dfcaad0022R397)

**Rendering Logic Updates:**

* Added a new `drawRadiusPreview` function to draw a dashed circle around tokens that reveal fog, representing the current reveal radius during preview.
* Updated the main rendering loop in `useMapRenderer` to call `drawRadiusPreview` when the preview is active and the user is in DM view, ensuring the preview is only shown at the appropriate times.