### PR TITLE
Save map data

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -65,8 +65,16 @@ Hash-based routing in `App.tsx`:
 
 `DataStore` class (`src/persistence/storage.ts`) — single instance exported as `dataStore`.
 
-- Storage keys: `dnd-ct:combats:v1`, `dnd-ct:players:v1`, `dnd-ct:monsters:v1`, `dnd-ct:blocks:v1`, `dnd-ct:campaigns:v1`, `dnd-ct:block-types:v1`
-- Backed by `CombatStorageProvider` / `CombatantTemplateStorageProvider` / `BuildingBlockStorageProvider` / `CampaignStorageProvider` / `BlockTypeStorageProvider` (all localStorage)
+- Storage keys: `dnd-ct:combats:v1`, `dnd-ct:players:v1`, `dnd-ct:monsters:v1`, `dnd-ct:blocks:v1`, `dnd-ct:campaigns:v1`, `dnd-ct:block-types:v1`, `dnd-ct:map-state:v1`
+- All keys are constants in `src/constants.ts` — always add new keys there, never inline strings
+- Backed by one `*StorageProvider` class per entity type (all localStorage) — see `src/persistence/`
+
+**IMPORTANT — how to add persistence for a new data type:**
+1. Add a storage key constant to `src/constants.ts` following the `dnd-ct:<entity>:v<version>` pattern
+2. Create `src/persistence/<Entity>StorageProvider.ts` — a plain class with `get`/`set` (single object) or `list`/`get`/`create`/`update`/`delete` (collection). See `MapStateStorageProvider` (single object) or `CampaignStorageProvider` (collection) for reference.
+3. Inject the provider into `DataStore` (constructor default + private field) and expose methods on it
+4. **Never** bypass `DataStore` by writing to `localStorage` directly in components or hooks — all persistence goes through `dataStore.*` calls
+5. Wire into sync: add the field to `SyncData` (`src/api/sync/types.ts`), include it in `getLocalSyncData()` and `applyRemoteData()` in `GoogleDriveSyncProvider.ts`, and handle it in `mergeSyncData.ts`
 
 **Storage optimization** (`src/persistence/combatStateOptimizer.ts`): combatants from libraries/parked groups are stored as lightweight references (`isReference: true`) with only delta fields vs. the template. Restored to full objects via `restoreCombatState()` on load.
 

--- a/src/api/sync/gdrive/GoogleDriveSyncProvider.ts
+++ b/src/api/sync/gdrive/GoogleDriveSyncProvider.ts
@@ -7,6 +7,7 @@ import {
   COMBAT_STORAGE_KEY,
   LAST_BACKUP_STORAGE_KEY,
   LAST_SYNC_STORAGE_KEY,
+  MAP_STATE_STORAGE_KEY,
   MONSTER_STORAGE_KEY,
   PLAYER_STORAGE_KEY,
 } from "../../../constants";
@@ -53,6 +54,7 @@ export class GoogleDriveSyncProvider implements SyncProvider {
       blocks: localStorage.getItem(BUILDING_BLOCK_STORAGE_KEY),
       campaigns: localStorage.getItem(CAMPAIGN_STORAGE_KEY),
       blockTypes: localStorage.getItem(BLOCK_TYPE_STORAGE_KEY),
+      mapState: localStorage.getItem(MAP_STATE_STORAGE_KEY),
       lastSynced: Date.now(),
     };
   }
@@ -184,5 +186,7 @@ export class GoogleDriveSyncProvider implements SyncProvider {
       localStorage.setItem(CAMPAIGN_STORAGE_KEY, data.campaigns);
     if (data.blockTypes)
       localStorage.setItem(BLOCK_TYPE_STORAGE_KEY, data.blockTypes);
+    if (data.mapState)
+      localStorage.setItem(MAP_STATE_STORAGE_KEY, data.mapState);
   }
 }

--- a/src/api/sync/gdrive/mergeSyncData.ts
+++ b/src/api/sync/gdrive/mergeSyncData.ts
@@ -98,6 +98,8 @@ export function mergeSyncData(
     blocks: mergeField(localRaw.blocks, remoteRaw.blocks),
     campaigns: mergeField(localRaw.campaigns, remoteRaw.campaigns),
     blockTypes: safeStringify(mergedBlockTypes),
+    // Single global object — remote wins, fallback to local
+    mapState: remoteRaw.mapState ?? localRaw.mapState ?? null,
     lastSynced: Date.now(),
   };
 }

--- a/src/api/sync/gdrive/tests/mergeSyncData.test.ts
+++ b/src/api/sync/gdrive/tests/mergeSyncData.test.ts
@@ -24,6 +24,7 @@ const syncWith = (field: keyof SyncData, entities: Entity[]): SyncData => ({
   blocks: null,
   campaigns: null,
   blockTypes: null,
+  mapState: null,
   lastSynced: 0,
   [field]: JSON.stringify(entities),
 });

--- a/src/api/sync/types.ts
+++ b/src/api/sync/types.ts
@@ -5,6 +5,7 @@ export interface SyncData {
   blocks: string | null;
   campaigns: string | null;
   blockTypes?: string | null;
+  mapState?: string | null;
   lastSynced: number;
 }
 

--- a/src/components/MapViewer/MapViewer.tsx
+++ b/src/components/MapViewer/MapViewer.tsx
@@ -2,6 +2,7 @@ import { Loader2, X } from "lucide-react";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { MAP_ROOM_CODE_STORAGE_KEY } from "../../constants";
+import { dataStore } from "../../persistence/storage";
 import PeerJSConnector from "./PeerJSConnector";
 import MapToolbar from "./components/MapToolbar";
 import TokenModal from "./components/TokenModal";
@@ -44,6 +45,8 @@ const DEFAULT_MAP_STATE: MapState = {
 export const PLAYER_WINDOW_NAME = "dnd-map-player-view";
 
 export default function MapViewer() {
+  const saveDebounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
   const [view, setView] = useState<"dm" | "player">(
     window.name === PLAYER_WINDOW_NAME ? "player" : "dm",
   );
@@ -56,8 +59,20 @@ export default function MapViewer() {
   );
   const [isReconnecting, setIsReconnecting] = useState(false);
 
-  const [mapState, setMapState] = useState<MapState>(DEFAULT_MAP_STATE);
-  const [camera, setCamera] = useState<Camera>({ x: 0, y: 0, scale: 1 });
+  const [mapState, setMapState] = useState<MapState>(() => {
+    const saved = dataStore.getMapState();
+    return saved
+      ? {
+          imageDataUrl: null,
+          tokens: saved.tokens,
+          revealedZones: saved.revealedZones,
+        }
+      : DEFAULT_MAP_STATE;
+  });
+  const [camera, setCamera] = useState<Camera>(() => {
+    const saved = dataStore.getMapState();
+    return saved?.camera ?? { x: 0, y: 0, scale: 1 };
+  });
   const [undoStack, setUndoStack] = useState<HistoryEntry[]>([]);
   const [redoStack, setRedoStack] = useState<HistoryEntry[]>([]);
   const [revealRadius, setRevealRadius] = useState(145);
@@ -89,6 +104,29 @@ export default function MapViewer() {
       localStorage.removeItem(MAP_ROOM_CODE_STORAGE_KEY);
     }
   }, [lastRoomCode]);
+
+  // Auto-save token positions, fog zones, and camera (debounced)
+  useEffect(() => {
+    if (saveDebounceRef.current !== null) clearTimeout(saveDebounceRef.current);
+    saveDebounceRef.current = setTimeout(() => {
+      dataStore.setMapState({
+        tokens: mapState.tokens.map(
+          ({ id, x, y, radius, color, label, hidden, revealsFog }) => ({
+            id,
+            x,
+            y,
+            radius,
+            color,
+            label,
+            hidden,
+            revealsFog,
+          }),
+        ),
+        revealedZones: mapState.revealedZones,
+        camera,
+      });
+    }, 500);
+  }, [mapState, camera]);
 
   // Warn before leaving when a map is loaded
   useEffect(() => {

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -90,6 +90,7 @@ export const BUILDING_BLOCK_STORAGE_KEY = "dnd-ct:blocks:v1";
 export const CAMPAIGN_STORAGE_KEY = "dnd-ct:campaigns:v1";
 export const BLOCK_TYPE_STORAGE_KEY = "dnd-ct:block-types:v1";
 export const MAP_ROOM_CODE_STORAGE_KEY = "dnd-ct:map-room-code";
+export const MAP_STATE_STORAGE_KEY = "dnd-ct:map-state:v1";
 export const BACKUP_FILE_NAME = "dnd-combat-tracker.backup.json";
 export const LAST_BACKUP_STORAGE_KEY = "dnd-ct:lastBackup";
 

--- a/src/persistence/MapStateStorageProvider.ts
+++ b/src/persistence/MapStateStorageProvider.ts
@@ -1,0 +1,42 @@
+export interface PersistedMapToken {
+  id: string;
+  x: number;
+  y: number;
+  radius: number;
+  color: string;
+  label?: string;
+  hidden: boolean;
+  revealsFog: boolean;
+}
+
+export interface PersistedMapMeta {
+  tokens: PersistedMapToken[];
+  revealedZones: { x: number; y: number; radius: number }[];
+  camera: { x: number; y: number; scale: number };
+}
+
+export class MapStateStorageProvider {
+  private key: string;
+
+  constructor(key: string) {
+    this.key = key;
+  }
+
+  get(): PersistedMapMeta | null {
+    try {
+      const raw = localStorage.getItem(this.key);
+      if (!raw) return null;
+      return JSON.parse(raw) as PersistedMapMeta;
+    } catch {
+      return null;
+    }
+  }
+
+  set(meta: PersistedMapMeta): void {
+    try {
+      localStorage.setItem(this.key, JSON.stringify(meta));
+    } catch {
+      // localStorage quota exceeded — silently ignore
+    }
+  }
+}

--- a/src/persistence/storage.ts
+++ b/src/persistence/storage.ts
@@ -5,6 +5,7 @@ import {
   BUILDING_BLOCK_STORAGE_KEY,
   CAMPAIGN_STORAGE_KEY,
   COMBAT_STORAGE_KEY,
+  MAP_STATE_STORAGE_KEY,
   MONSTER_STORAGE_KEY,
   PLAYER_STORAGE_KEY,
 } from "../constants";
@@ -30,6 +31,10 @@ import {
 } from "./BlockTypeStorageProvider";
 import { CampaignStorageProvider } from "./CampaignStorageProvider";
 import {
+  MapStateStorageProvider,
+  type PersistedMapMeta,
+} from "./MapStateStorageProvider";
+import {
   cleanCombatStateForStorage,
   restoreCombatState,
 } from "./combatStateOptimizer";
@@ -41,6 +46,7 @@ export class DataStore {
   private blockProvider: BuildingBlockStorageProvider;
   private blockTypeProvider: BlockTypeStorageProvider;
   private campaignProvider: CampaignStorageProvider;
+  private mapStateProvider: MapStateStorageProvider;
   private syncProvider: SyncProvider;
 
   constructor(
@@ -63,6 +69,9 @@ export class DataStore {
     campaignProvider: CampaignStorageProvider = new CampaignStorageProvider(
       CAMPAIGN_STORAGE_KEY,
     ),
+    mapStateProvider: MapStateStorageProvider = new MapStateStorageProvider(
+      MAP_STATE_STORAGE_KEY,
+    ),
   ) {
     this.combatProvider = combatProvider;
     this.playerProvider = playerProvider;
@@ -70,6 +79,7 @@ export class DataStore {
     this.blockProvider = blockProvider;
     this.blockTypeProvider = blockTypeProvider;
     this.campaignProvider = campaignProvider;
+    this.mapStateProvider = mapStateProvider;
     this.syncProvider = new GoogleDriveSyncProvider(clientId);
   }
 
@@ -278,6 +288,14 @@ export class DataStore {
   }
   deleteCampaign(id: string): Promise<void> {
     return this.campaignProvider.delete(id);
+  }
+
+  // Map state methods
+  getMapState(): PersistedMapMeta | null {
+    return this.mapStateProvider.get();
+  }
+  setMapState(meta: PersistedMapMeta): void {
+    this.mapStateProvider.set(meta);
   }
 }
 


### PR DESCRIPTION
This pull request adds persistent local storage and sync support for the map state (token positions, fog zones, and camera) in the application. The changes ensure that map state is saved automatically, restored on reload, and included in Google Drive sync and merge operations. The implementation follows the project's data persistence conventions and introduces a dedicated storage provider for map state.

**Persistence and Sync Enhancements:**

* Added a new constant `MAP_STATE_STORAGE_KEY` in `src/constants.ts` for storing map state, and updated documentation in `CLAUDE.md` to require all storage keys to be defined as constants. [[1]](diffhunk://#diff-8fa4b52909f895e8cda060d2035234e0a42ca2c7d3f8f8de1b35a056537bf199R93) [[2]](diffhunk://#diff-6ebdb617a8104a7756d0cf36578ab01103dc9f07e4dc6feb751296b9c402faf7L68-R77)
* Implemented `MapStateStorageProvider` (`src/persistence/MapStateStorageProvider.ts`) to handle get/set operations for the persisted map state object, and integrated it into the `DataStore` class with `getMapState`/`setMapState` methods. [[1]](diffhunk://#diff-b855875e972c6d6bdff1440e272e47548023b6bba8855639f1d597d0e357621bR1-R42) [[2]](diffhunk://#diff-9003b0c63253113c0842da86c71d094553d466919a9b1944939018e1fe9443a7R33-R36) [[3]](diffhunk://#diff-9003b0c63253113c0842da86c71d094553d466919a9b1944939018e1fe9443a7R49) [[4]](diffhunk://#diff-9003b0c63253113c0842da86c71d094553d466919a9b1944939018e1fe9443a7R72-R82) [[5]](diffhunk://#diff-9003b0c63253113c0842da86c71d094553d466919a9b1944939018e1fe9443a7R292-R299)
* Updated `MapViewer` to auto-save map state (tokens, fog, camera) to persistent storage (debounced), and to restore state from storage on load. [[1]](diffhunk://#diff-196cae4265e24183d95df0f1d1730b57220be6e4ef02e6896a307e7f6d2b927fR5) [[2]](diffhunk://#diff-196cae4265e24183d95df0f1d1730b57220be6e4ef02e6896a307e7f6d2b927fR48-R49) [[3]](diffhunk://#diff-196cae4265e24183d95df0f1d1730b57220be6e4ef02e6896a307e7f6d2b927fL59-R75) [[4]](diffhunk://#diff-196cae4265e24183d95df0f1d1730b57220be6e4ef02e6896a307e7f6d2b927fR108-R130)

**Google Drive Sync Integration:**

* Extended the sync data model (`SyncData` in `src/api/sync/types.ts`) and sync/merge logic to include the map state, ensuring it is uploaded, downloaded, and merged correctly. [[1]](diffhunk://#diff-a7e052aeff17447553572a93997b7cd7ebe2e3a12b33378212575cf2b3372089R8) [[2]](diffhunk://#diff-cf1a52c94f1299a4c181d4eb1ee07e4540f674affdec30a509961fad91cdb30dR10) [[3]](diffhunk://#diff-cf1a52c94f1299a4c181d4eb1ee07e4540f674affdec30a509961fad91cdb30dR57) [[4]](diffhunk://#diff-cf1a52c94f1299a4c181d4eb1ee07e4540f674affdec30a509961fad91cdb30dR189-R190) [[5]](diffhunk://#diff-1b7918e4395e2b5bfb93470b50cbe26307a1988be8d634bb9e8d8946461872c1R101-R102) [[6]](diffhunk://#diff-4aefe1552454272eb30250e71b113c300703536b3809171d3568f8a4d48f3471R27)

**Documentation and Developer Guidance:**

* Updated `CLAUDE.md` with clear instructions for adding persistence for new data types, emphasizing the use of constants and the `DataStore` abstraction.

These changes ensure that map state is reliably persisted and synchronized, following best practices for maintainability and extensibility.