### PR TITLE
Token context menu

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -70,6 +70,7 @@ Hash-based routing in `App.tsx`:
 - Backed by one `*StorageProvider` class per entity type (all localStorage) — see `src/persistence/`
 
 **IMPORTANT — how to add persistence for a new data type:**
+
 1. Add a storage key constant to `src/constants.ts` following the `dnd-ct:<entity>:v<version>` pattern
 2. Create `src/persistence/<Entity>StorageProvider.ts` — a plain class with `get`/`set` (single object) or `list`/`get`/`create`/`update`/`delete` (collection). See `MapStateStorageProvider` (single object) or `CampaignStorageProvider` (collection) for reference.
 3. Inject the provider into `DataStore` (constructor default + private field) and expose methods on it

--- a/src/components/MapViewer/MapViewer.tsx
+++ b/src/components/MapViewer/MapViewer.tsx
@@ -6,6 +6,7 @@ import { MAP_ROOM_CODE_STORAGE_KEY } from "../../constants";
 import { dataStore } from "../../persistence/storage";
 import PeerJSConnector from "./PeerJSConnector";
 import MapToolbar from "./components/MapToolbar";
+import TokenContextMenu from "./components/TokenContextMenu";
 import TokenModal from "./components/TokenModal";
 import { useMapInteraction } from "./hooks/useMapInteraction";
 import { useMapRenderer } from "./hooks/useMapRenderer";
@@ -84,6 +85,11 @@ export default function MapViewer() {
   const [portraitViewTokenId, setPortraitViewTokenId] = useState<string | null>(
     null,
   );
+  const [contextMenu, setContextMenu] = useState<{
+    tokenId: string;
+    x: number;
+    y: number;
+  } | null>(null);
 
   // Shared refs
   const canvasRef = useRef<HTMLCanvasElement>(null);
@@ -175,6 +181,7 @@ export default function MapViewer() {
     handleMouseMove,
     handleMouseUp,
     handleMouseLeave,
+    handleContextMenu,
     updateToken,
     addToken,
     removeToken,
@@ -210,6 +217,11 @@ export default function MapViewer() {
     onFocusToken: useCallback((x: number, y: number) => {
       transportRef.current?.send({ type: "FOCUS_TOKEN", x, y });
     }, []),
+    onContextMenuToken: useCallback(
+      (tokenId: string, x: number, y: number) =>
+        setContextMenu({ tokenId, x, y }),
+      [],
+    ),
   });
 
   useMapRenderer({
@@ -307,6 +319,9 @@ export default function MapViewer() {
 
   const portraitToken = portraitViewTokenId
     ? (mapState.tokens.find((t) => t.id === portraitViewTokenId) ?? null)
+    : null;
+  const contextMenuToken = contextMenu
+    ? (mapState.tokens.find((t) => t.id === contextMenu.tokenId) ?? null)
     : null;
 
   const cursorStyle = isPointerMode
@@ -478,7 +493,32 @@ export default function MapViewer() {
         onMouseMove={handleMouseMove}
         onMouseUp={handleMouseUp}
         onMouseLeave={handleMouseLeave}
+        onContextMenu={handleContextMenu}
       />
+
+      {contextMenu && contextMenuToken && (
+        <TokenContextMenu
+          token={contextMenuToken}
+          x={contextMenu.x}
+          y={contextMenu.y}
+          onClose={() => setContextMenu(null)}
+          onToggleVisibility={() => {
+            updateToken(contextMenuToken.id, {
+              hidden: !contextMenuToken.hidden,
+            });
+            setContextMenu(null);
+          }}
+          onEdit={() => {
+            setSelectedTokenId(contextMenu.tokenId);
+            setTokenModalOpen(true);
+            setContextMenu(null);
+          }}
+          onDelete={() => {
+            removeToken(contextMenu.tokenId);
+            setContextMenu(null);
+          }}
+        />
+      )}
     </div>
   );
 }

--- a/src/components/MapViewer/components/TokenContextMenu.tsx
+++ b/src/components/MapViewer/components/TokenContextMenu.tsx
@@ -1,0 +1,87 @@
+import { Eye, EyeOff, Pencil, Trash2 } from "lucide-react";
+import { useEffect, useRef } from "react";
+import { createPortal } from "react-dom";
+import { useTranslation } from "react-i18next";
+import type { Token } from "../types";
+
+interface Props {
+  token: Token;
+  x: number;
+  y: number;
+  onClose: () => void;
+  onToggleVisibility: () => void;
+  onEdit: () => void;
+  onDelete: () => void;
+}
+
+const MENU_WIDTH = 160;
+const MENU_HEIGHT = 112;
+
+export default function TokenContextMenu({
+  token,
+  x,
+  y,
+  onClose,
+  onToggleVisibility,
+  onEdit,
+  onDelete,
+}: Props) {
+  const { t } = useTranslation("map");
+  const menuRef = useRef<HTMLDivElement>(null);
+
+  // Clamp so menu never goes off-screen
+  const left = Math.min(x, window.innerWidth - MENU_WIDTH - 8);
+  const top = Math.min(y, window.innerHeight - MENU_HEIGHT - 8);
+
+  useEffect(() => {
+    const handleKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") onClose();
+    };
+    const handleMouseDown = (e: MouseEvent) => {
+      if (menuRef.current && !menuRef.current.contains(e.target as Node)) {
+        onClose();
+      }
+    };
+    document.addEventListener("keydown", handleKey);
+    document.addEventListener("mousedown", handleMouseDown);
+    return () => {
+      document.removeEventListener("keydown", handleKey);
+      document.removeEventListener("mousedown", handleMouseDown);
+    };
+  }, [onClose]);
+
+  return createPortal(
+    <div
+      ref={menuRef}
+      className="fixed z-50 bg-panel-bg border border-border-primary rounded-lg shadow-xl py-1 min-w-[160px]"
+      style={{ left, top }}
+    >
+      <button
+        className="w-full flex items-center gap-2.5 px-3 py-2 text-sm text-text-primary hover:bg-panel-secondary transition-colors"
+        onClick={onToggleVisibility}
+      >
+        {token.hidden ? (
+          <Eye className="w-4 h-4 shrink-0" />
+        ) : (
+          <EyeOff className="w-4 h-4 shrink-0" />
+        )}
+        {token.hidden ? t("contextMenu.show") : t("contextMenu.hide")}
+      </button>
+      <button
+        className="w-full flex items-center gap-2.5 px-3 py-2 text-sm text-text-primary hover:bg-panel-secondary transition-colors"
+        onClick={onEdit}
+      >
+        <Pencil className="w-4 h-4 shrink-0" />
+        {t("contextMenu.edit")}
+      </button>
+      <button
+        className="w-full flex items-center gap-2.5 px-3 py-2 text-sm text-red-400 hover:bg-panel-secondary transition-colors"
+        onClick={onDelete}
+      >
+        <Trash2 className="w-4 h-4 shrink-0" />
+        {t("contextMenu.delete")}
+      </button>
+    </div>,
+    document.body,
+  );
+}

--- a/src/components/MapViewer/hooks/useMapInteraction.ts
+++ b/src/components/MapViewer/hooks/useMapInteraction.ts
@@ -22,6 +22,23 @@ function screenToWorld(
   };
 }
 
+function findClosestToken(
+  tokens: Token[],
+  worldX: number,
+  worldY: number,
+): Token | null {
+  let closest: Token | null = null;
+  let closestDist = Infinity;
+  for (const token of tokens) {
+    const d = Math.hypot(worldX - token.x, worldY - token.y);
+    if (d <= token.radius * 1.5 && d < closestDist) {
+      closestDist = d;
+      closest = token;
+    }
+  }
+  return closest;
+}
+
 interface Params {
   view: "dm" | "player";
   canvasRef: React.RefObject<HTMLCanvasElement | null>;
@@ -40,6 +57,7 @@ interface Params {
   setSelectedTokenId: React.Dispatch<React.SetStateAction<string | null>>;
   onTokenTap: (tokenId: string) => void;
   onFocusToken: (x: number, y: number) => void;
+  onContextMenuToken: (tokenId: string, x: number, y: number) => void;
 }
 
 export function useMapInteraction({
@@ -60,6 +78,7 @@ export function useMapInteraction({
   setSelectedTokenId,
   onTokenTap,
   onFocusToken,
+  onContextMenuToken,
 }: Params) {
   // Owned refs — internal to interaction logic
   const draggingTokenIdRef = useRef<string | null>(null);
@@ -112,15 +131,7 @@ export function useMapInteraction({
       const { tokens } = mapStateRef.current!;
       const visibleTokens =
         view === "player" ? tokens.filter((t) => !t.hidden) : tokens;
-      let closest: Token | null = null;
-      let closestDist = Infinity;
-      for (const token of visibleTokens) {
-        const d = Math.hypot(world.x - token.x, world.y - token.y);
-        if (d <= token.radius * 1.5 && d < closestDist) {
-          closestDist = d;
-          closest = token;
-        }
-      }
+      const closest = findClosestToken(visibleTokens, world.x, world.y);
       if (closest) {
         tapTokenIdRef.current = closest.id;
         tokenDragStartScreenRef.current = { sx, sy };
@@ -253,6 +264,25 @@ export function useMapInteraction({
       setUndoStack,
       setRedoStack,
     ],
+  );
+
+  // --- Context menu ---
+
+  const handleContextMenu = useCallback(
+    (e: React.MouseEvent<HTMLCanvasElement>) => {
+      if (view !== "dm") return;
+      e.preventDefault();
+      const rect = (e.target as HTMLCanvasElement).getBoundingClientRect();
+      const world = screenToWorld(
+        e.clientX - rect.left,
+        e.clientY - rect.top,
+        cameraRef.current!,
+      );
+      const { tokens } = mapStateRef.current!;
+      const closest = findClosestToken(tokens, world.x, world.y);
+      if (closest) onContextMenuToken(closest.id, e.clientX, e.clientY);
+    },
+    [view, cameraRef, mapStateRef, onContextMenuToken],
   );
 
   // --- Mouse handlers ---
@@ -673,6 +703,7 @@ export function useMapInteraction({
     handleMouseMove,
     handleMouseUp,
     handleMouseLeave,
+    handleContextMenu,
     updateToken,
     addToken,
     removeToken,

--- a/src/i18n/locales/en/map.json
+++ b/src/i18n/locales/en/map.json
@@ -52,6 +52,12 @@
     "connectionFailed": "Connection failed",
     "tryAgain": "Try again"
   },
+  "contextMenu": {
+    "show": "Show",
+    "hide": "Hide",
+    "edit": "Edit",
+    "delete": "Delete"
+  },
   "token": {
     "playerToken": "Player Token",
     "token": "Token",

--- a/src/i18n/locales/fr/map.json
+++ b/src/i18n/locales/fr/map.json
@@ -52,6 +52,12 @@
     "connectionFailed": "Connexion échouée",
     "tryAgain": "Réessayer"
   },
+  "contextMenu": {
+    "show": "Afficher",
+    "hide": "Masquer",
+    "edit": "Modifier",
+    "delete": "Supprimer"
+  },
   "token": {
     "playerToken": "Pion du Joueur",
     "token": "Pion",


### PR DESCRIPTION
This pull request adds a right-click context menu for map tokens in the `MapViewer` component, improving the DM (Dungeon Master) user experience by allowing quick actions on tokens such as show/hide, edit, and delete. The implementation includes a new `TokenContextMenu` component, interaction logic for detecting right-clicks on tokens, and localization support for the new menu actions.

**Map Token Context Menu Feature:**

* Added a new `TokenContextMenu` component that appears on right-clicking a token (DM view only), providing options to show/hide, edit, or delete the token. The menu is positioned near the cursor and closes on outside click or Escape key. (`src/components/MapViewer/components/TokenContextMenu.tsx`)
* Updated `MapViewer` state and rendering logic to handle context menu visibility, pass the relevant token and actions to the menu, and integrate with existing token update/delete flows. (`src/components/MapViewer/MapViewer.tsx`) [[1]](diffhunk://#diff-196cae4265e24183d95df0f1d1730b57220be6e4ef02e6896a307e7f6d2b927fR9) [[2]](diffhunk://#diff-196cae4265e24183d95df0f1d1730b57220be6e4ef02e6896a307e7f6d2b927fR88-R92) [[3]](diffhunk://#diff-196cae4265e24183d95df0f1d1730b57220be6e4ef02e6896a307e7f6d2b927fR184) [[4]](diffhunk://#diff-196cae4265e24183d95df0f1d1730b57220be6e4ef02e6896a307e7f6d2b927fR220-R224) [[5]](diffhunk://#diff-196cae4265e24183d95df0f1d1730b57220be6e4ef02e6896a307e7f6d2b927fR323-R325) [[6]](diffhunk://#diff-196cae4265e24183d95df0f1d1730b57220be6e4ef02e6896a307e7f6d2b927fR496-R521)

**Interaction and Logic Enhancements:**

* Extended the `useMapInteraction` hook to support right-click detection (`handleContextMenu`), token proximity calculation, and callback wiring for context menu actions. (`src/components/MapViewer/hooks/useMapInteraction.ts`) [[1]](diffhunk://#diff-e78b954930476bf9ec514d86ebe4bb452374ec3519efd137cb9a44ba189cb15dR25-R41) [[2]](diffhunk://#diff-e78b954930476bf9ec514d86ebe4bb452374ec3519efd137cb9a44ba189cb15dR60) [[3]](diffhunk://#diff-e78b954930476bf9ec514d86ebe4bb452374ec3519efd137cb9a44ba189cb15dR81) [[4]](diffhunk://#diff-e78b954930476bf9ec514d86ebe4bb452374ec3519efd137cb9a44ba189cb15dL115-R134) [[5]](diffhunk://#diff-e78b954930476bf9ec514d86ebe4bb452374ec3519efd137cb9a44ba189cb15dR269-R287) [[6]](diffhunk://#diff-e78b954930476bf9ec514d86ebe4bb452374ec3519efd137cb9a44ba189cb15dR706)

**Localization:**

* Added English and French translations for the new context menu actions ("Show", "Hide", "Edit", "Delete"). (`src/i18n/locales/en/map.json`, `src/i18n/locales/fr/map.json`) [[1]](diffhunk://#diff-c448f16f60235f6e5c78f7a5d8391a1d4682a08f2615f1042621ed1f0b497728R55-R60) [[2]](diffhunk://#diff-5f8c08e534aa23cb6858e44df085f4c7e58047c08a8369100e18b04831715589R55-R60)

**Documentation:**

* Minor update to the persistence documentation in `CLAUDE.md` for clarity.